### PR TITLE
解决后台扫描游戏时列表会不停重载 使封面放大并居中显示

### DIFF
--- a/GalgameManager/Services/GalgameCollectionService.cs
+++ b/GalgameManager/Services/GalgameCollectionService.cs
@@ -64,9 +64,13 @@ public class GalgameCollectionService : IDataCollectionService<Galgame>
     /// </summary>
     private void UpdateDisplayGalgames()
     {
-        _displayGalgames.Clear();
-        foreach(Galgame gal in _galgames)
+        foreach (Galgame gal in _galgames) {
+            if (_displayGalgames.Contains(gal))
+            {
+                continue;
+            }
             _displayGalgames.Add(gal);
+        }
     }
 
     /// <summary>

--- a/GalgameManager/Views/HomePage.xaml
+++ b/GalgameManager/Views/HomePage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="GalgameManager.Views.HomePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -70,10 +70,12 @@
                             Padding="{StaticResource XSmallLeftTopRightBottomMargin}"
                             ContextFlyout="{StaticResource GalFlyout}">
                             <StackPanel HorizontalAlignment="Center">
-                                <Image
-                                    Source="{x:Bind ImagePath.Value}"
-                                    Height="230"
-                                    Width="150" />
+                                <Rectangle                                     Height="230"
+                                    Width="150" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <Rectangle.Fill>
+                                        <ImageBrush ImageSource="{x:Bind ImagePath.Value}" Stretch="UniformToFill"/>
+                                    </Rectangle.Fill>
+                                </Rectangle>
                                 <TextBlock
                                     Margin="{StaticResource XXSmallTopMargin}"
                                     HorizontalAlignment="Center"


### PR DESCRIPTION
解决后台扫描游戏时列表会不停重载
使封面放大并居中显示