### PR TITLE
[FEAT] 限制递归搜索子目录的深度

### DIFF
--- a/GalgameManager/Services/LocalSettingsService.cs
+++ b/GalgameManager/Services/LocalSettingsService.cs
@@ -82,6 +82,8 @@ public class LocalSettingsService : ILocalSettingsService
                 return (T?)(object?)SortKeys.Developer;
             case KeyValues.SearchChildFolder:
                 return (T?)(object?)false;
+            case KeyValues.SearchChildFolderDepth:
+                return (T?)(object?)1;
             case KeyValues.RegexPattern:
                 return (T?)(object?)@".+";
             case KeyValues.GameFolderMustContain:
@@ -108,7 +110,7 @@ public class LocalSettingsService : ILocalSettingsService
             await Task.Run(() => _fileService.Save(_applicationDataFolder, _localsettingsFile, _settings));
         }
     }
-    
+
     public async Task RemoveSettingAsync(string key)
     {
         if (RuntimeHelper.IsMSIX)
@@ -140,6 +142,7 @@ public static class KeyValues
     public const string SortKey1 = "sortKey1";
     public const string SortKey2 = "sortKey2";
     public const string SearchChildFolder = "searchChildFolder";
+    public const string SearchChildFolderDepth = "searchChildFolderDepth";
     public const string RegexPattern = "regexPattern";
     public const string RegexIndex = "regexIndex";
     public const string RegexRemoveBorder = "regexRemoveBorder";

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -332,6 +332,12 @@
   <data name="SettingsPage_Library_SearchSubPathDescription" xml:space="preserve">
     <value>是否要递归搜索子目录，如果不选中则只搜索游戏库根目录的子文件夹</value>
   </data>
+  <data name="SettingsPage_Library_SearchSubPathDepth" xml:space="preserve">
+    <value>递归搜索深度</value>
+  </data>
+  <data name="SettingsPage_Library_SearchSubPathDepthDescription" xml:space="preserve">
+    <value>限制递归搜索子目录的深度</value>
+  </data>
   <data name="SettingsPage_Library_NameDescription" xml:space="preserve">
     <value>本软件会用正则表达式匹配游戏文件夹名字，并取选定的匹配子串作游戏名。
 不了解正则表达式的用户可以理解为：本软件会把游戏文件夹名字当做游戏名字。</value>

--- a/GalgameManager/ViewModels/SettingsViewModel.cs
+++ b/GalgameManager/ViewModels/SettingsViewModel.cs
@@ -45,6 +45,8 @@ public partial class SettingsViewModel : ObservableRecipient
     public readonly string UiLibraryDescription = "SettingsPage_LibraryDescription".GetLocalized();
     public readonly string UiLibrarySearchSubPath = "SettingsPage_Library_SearchSubPath".GetLocalized();
     public readonly string UiLibrarySearchSubPathDescription = "SettingsPage_Library_SearchSubPathDescription".GetLocalized();
+    public readonly string UiLibrarySearchSubPathDepth = "SettingsPage_Library_SearchSubPathDepth".GetLocalized();
+    public readonly string UiLibrarySearchSubPathDepthDescription = "SettingsPage_Library_SearchSubPathDepthDescription".GetLocalized();
     public readonly string UiLibraryNameDescription = "SettingsPage_Library_NameDescription".GetLocalized();
     public readonly string UiLibrarySearchRegex = "SettingsPage_Library_SearchRegex".GetLocalized();
     public readonly string UiLibrarySearchRegexDescription = "SettingsPage_Library_SearchRegexDescription".GetLocalized();
@@ -104,6 +106,7 @@ public partial class SettingsViewModel : ObservableRecipient
         _overrideLocalName = _localSettingsService.ReadSettingAsync<bool>(KeyValues.OverrideLocalName).Result;
         //LIBRARY
         _searchSubFolder = _localSettingsService.ReadSettingAsync<bool>(KeyValues.SearchChildFolder).Result;
+        _searchSubFolderDepth = _localSettingsService.ReadSettingAsync<int>(KeyValues.SearchChildFolderDepth).Result;
         _regex = _localSettingsService.ReadSettingAsync<string>(KeyValues.RegexPattern).Result ?? ".+";
         _regexIndex = _localSettingsService.ReadSettingAsync<int>(KeyValues.RegexIndex).Result;
         _regexRemoveBorder = _localSettingsService.ReadSettingAsync<bool>(KeyValues.RegexRemoveBorder).Result;
@@ -163,6 +166,7 @@ public partial class SettingsViewModel : ObservableRecipient
     #region LIBRARY
 
     [ObservableProperty] private bool _searchSubFolder;
+    [ObservableProperty] private int _searchSubFolderDepth;
     [ObservableProperty] private string _regex;
     [ObservableProperty] private int _regexIndex;
     [ObservableProperty] private bool _regexRemoveBorder;
@@ -171,6 +175,8 @@ public partial class SettingsViewModel : ObservableRecipient
     [ObservableProperty] private string _regexTryItOut = "";
 
     partial void OnSearchSubFolderChanged(bool value) => _localSettingsService.SaveSettingAsync(KeyValues.SearchChildFolder, value);
+
+    partial void OnSearchSubFolderDepthChanged(int value) => _localSettingsService.SaveSettingAsync(KeyValues.SearchChildFolderDepth, value);
 
     partial void OnRegexChanged(string value) => _localSettingsService.SaveSettingAsync(KeyValues.RegexPattern, value);
 

--- a/GalgameManager/Views/SettingsPage.xaml
+++ b/GalgameManager/Views/SettingsPage.xaml
@@ -10,6 +10,7 @@
     xmlns:control="using:GalgameManager.Views.Control"
     mc:Ignorable="d">
     <Page.Resources>
+        <converter:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <converter:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
         <converter:RssTypeToBooleanConverter x:Key="RssTypeToBooleanConverter" />
     </Page.Resources>
@@ -120,10 +121,24 @@
                         <StackPanel Orientation="Vertical" Spacing="13">
                             <!-- 递归搜索子目录 -->
                             <control:Panel>
-                                <local:SettingToggleSwitch
+                                <StackPanel>
+                                    <local:SettingToggleSwitch
                                     Title="{x:Bind ViewModel.UiLibrarySearchSubPath}"
                                     Description="{x:Bind ViewModel.UiLibrarySearchSubPathDescription}"
                                     IsOn="{x:Bind ViewModel.SearchSubFolder, Mode=TwoWay}" />
+                                    <RelativePanel Margin="{StaticResource XSmallTopMargin}" HorizontalAlignment="Stretch" 
+                                                   Visibility="{x:Bind ViewModel.SearchSubFolder, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                                        <StackPanel Orientation="Vertical">
+                                            <TextBlock Text="{x:Bind ViewModel.UiLibrarySearchSubPathDepth}"
+                                                   Style="{ThemeResource BodyTextBlockStyle}" />
+                                            <TextBlock Text="{x:Bind ViewModel.UiLibrarySearchSubPathDepthDescription}"
+                                                   FontSize="12"
+                                                   Opacity="0.6" />
+                                        </StackPanel>
+                                        <TextBox Text="{x:Bind ViewModel.SearchSubFolderDepth, Mode=TwoWay}"
+                                                 RelativePanel.AlignRightWithPanel="True" />
+                                    </RelativePanel>
+                                </StackPanel>
                             </control:Panel>
                             <!-- 正则表达式 -->
                             <control:Panel>


### PR DESCRIPTION
自己实现了<https://github.com/GoldenPotato137/GalgameManager/issues/12>提到的限制递归搜索子目录的深度。
主要思路就是将放入队列中的元素改为包含深度的元组，然后在设置中在选中`递归搜索子目录`时显示`递归搜索深度`选项。