### PR TITLE
修复GalgameSettingPage设置不居中问题，将Rating替换为数字输入框

### DIFF
--- a/GalgameManager/Views/Control/LockableNumberBox.xaml
+++ b/GalgameManager/Views/Control/LockableNumberBox.xaml
@@ -1,0 +1,46 @@
+<!-- Copyright (c) Microsoft Corporation and Contributors. -->
+<!-- Licensed under the MIT License. -->
+
+<UserControl
+    x:Class="GalgameManager.Views.Control.LockableNumberBox"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:numberFormatting="using:Windows.Globalization.NumberFormatting"
+    mc:Ignorable="d">
+
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"></ColumnDefinition>
+            <ColumnDefinition Width="*"></ColumnDefinition>
+            <ColumnDefinition Width="Auto"></ColumnDefinition>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Grid.Column="0"
+                   Style="{ThemeResource BodyTextBlockStyle}"
+                   Text="{x:Bind Title}"
+                   Margin="0 0 15 0"
+                   VerticalAlignment="Center">
+        </TextBlock>
+
+        <NumberBox Grid.Column="1"
+                   Value="{x:Bind Value, Mode=TwoWay}"
+                   IsEnabled="{x:Bind IsEditable, Mode=OneWay}"
+                   VerticalAlignment="Center"
+                   SpinButtonPlacementMode="Compact"
+                   SmallChange="0.1"
+                   LargeChange="1"
+                   Minimum="0.0"
+                   Maximum="10.0"
+                   x:Name="FormattedNumberBox">
+        </NumberBox>
+        
+        <ToggleSwitch Grid.Column="2"
+                      IsOn="{x:Bind IsLock, Mode=TwoWay}"
+                      Margin="30 0 -50 0"
+                      OnContent="已锁定"
+                      OffContent="已解锁">
+        </ToggleSwitch>
+    </Grid>
+</UserControl>

--- a/GalgameManager/Views/Control/LockableNumberBox.xaml.cs
+++ b/GalgameManager/Views/Control/LockableNumberBox.xaml.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Windows.Globalization.NumberFormatting;
+using Microsoft.UI.Xaml;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace GalgameManager.Views.Control;
+
+public sealed partial class LockableNumberBox : INotifyPropertyChanged
+{
+    public LockableNumberBox()
+    {
+        InitializeComponent();
+        IncrementNumberRounder rounder = new()
+        {
+            Increment = 0.1,
+            RoundingAlgorithm = RoundingAlgorithm.RoundUp
+        };
+
+        DecimalFormatter formatter = new()
+        {
+            IntegerDigits = 1,
+            FractionDigits = 1,
+            NumberRounder = rounder
+        };
+        FormattedNumberBox.NumberFormatter = formatter;
+    }
+
+    public string Title
+    {
+        get => (string)GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    public static readonly DependencyProperty TitleProperty =
+        DependencyProperty.Register(nameof(Title), typeof(string), typeof(LockableNumberBox), new PropertyMetadata(string.Empty));
+
+    public double Value
+    {
+        get => (double)GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    public static readonly DependencyProperty ValueProperty =
+        DependencyProperty.Register(nameof(Value), typeof(double), typeof(LockableNumberBox), new PropertyMetadata(0.0D));
+    
+    public bool Readonly
+    {
+        get => (bool)GetValue(ReadonlyProperty);
+        set => SetValue(ReadonlyProperty, value);
+    }
+
+    public static readonly DependencyProperty ReadonlyProperty =
+        DependencyProperty.Register(nameof(Readonly), typeof(bool), typeof(LockableNumberBox), new PropertyMetadata(false));
+
+    public bool IsLock
+    {
+        get => (bool)GetValue(IsLockProperty);
+
+        set
+        {
+            SetValue(IsLockProperty, value);
+            OnPropertyChanged(nameof(IsEditable));
+        }
+    }
+
+    public static readonly DependencyProperty IsLockProperty =
+        DependencyProperty.Register(nameof(IsLock), typeof(bool), typeof(LockableNumberBox), new PropertyMetadata(false));
+    
+    public bool IsEditable => !IsLock & !Readonly;
+        
+        
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/GalgameManager/Views/Control/LockableTextBox.xaml
+++ b/GalgameManager/Views/Control/LockableTextBox.xaml
@@ -2,7 +2,7 @@
 <!-- Licensed under the MIT License. -->
 
 <UserControl
-    x:Class="GalgameManager.Views.Control.LockableSetting"
+    x:Class="GalgameManager.Views.Control.LockableTextBox"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -26,7 +26,8 @@
         <TextBox Grid.Column="1"
                  Text="{x:Bind Value, Mode=TwoWay}"
                  IsEnabled="{x:Bind IsEditable, Mode=OneWay}"
-                 AcceptsReturn="True"
+                 AcceptsReturn="{x:Bind AcceptsReturn, Mode=OneWay}"
+                 VerticalAlignment="Center"
                  TextWrapping="Wrap"
                  IsSpellCheckEnabled="False">
         </TextBox>

--- a/GalgameManager/Views/Control/LockableTextBox.xaml.cs
+++ b/GalgameManager/Views/Control/LockableTextBox.xaml.cs
@@ -10,9 +10,9 @@ using Microsoft.UI.Xaml;
 
 namespace GalgameManager.Views.Control;
 
-public sealed partial class LockableSetting : INotifyPropertyChanged
+public sealed partial class LockableTextBox : INotifyPropertyChanged
 {
-    public LockableSetting()
+    public LockableTextBox()
     {
         this.InitializeComponent();
     }
@@ -24,7 +24,7 @@ public sealed partial class LockableSetting : INotifyPropertyChanged
     }
 
     public static readonly DependencyProperty TitleProperty =
-        DependencyProperty.Register(nameof(Title), typeof(string), typeof(LockableSetting), new PropertyMetadata(string.Empty));
+        DependencyProperty.Register(nameof(Title), typeof(string), typeof(LockableTextBox), new PropertyMetadata(string.Empty));
 
     public string Value
     {
@@ -33,7 +33,7 @@ public sealed partial class LockableSetting : INotifyPropertyChanged
     }
 
     public static readonly DependencyProperty ValueProperty =
-        DependencyProperty.Register(nameof(Value), typeof(string), typeof(LockableSetting), new PropertyMetadata(string.Empty));
+        DependencyProperty.Register(nameof(Value), typeof(string), typeof(LockableTextBox), new PropertyMetadata(string.Empty));
     
     public bool Readonly
     {
@@ -42,7 +42,7 @@ public sealed partial class LockableSetting : INotifyPropertyChanged
     }
 
     public static readonly DependencyProperty ReadonlyProperty =
-        DependencyProperty.Register(nameof(Readonly), typeof(bool), typeof(LockableSetting), new PropertyMetadata(false));
+        DependencyProperty.Register(nameof(Readonly), typeof(bool), typeof(LockableTextBox), new PropertyMetadata(false));
 
     public bool IsLock
     {
@@ -56,7 +56,21 @@ public sealed partial class LockableSetting : INotifyPropertyChanged
     }
 
     public static readonly DependencyProperty IsLockProperty =
-        DependencyProperty.Register(nameof(IsLock), typeof(bool), typeof(LockableSetting), new PropertyMetadata(false));
+        DependencyProperty.Register(nameof(IsLock), typeof(bool), typeof(LockableTextBox), new PropertyMetadata(false));
+    
+    public bool AcceptsReturn
+    {
+        get => (bool)GetValue(AcceptsReturnProperty);
+
+        set
+        {
+            SetValue(AcceptsReturnProperty, value);
+            OnPropertyChanged(nameof(IsEditable));
+        }
+    }
+
+    public static readonly DependencyProperty AcceptsReturnProperty =
+        DependencyProperty.Register(nameof(AcceptsReturn), typeof(bool), typeof(LockableTextBox), new PropertyMetadata(false));
 
     public bool IsEditable => !IsLock & !Readonly;
         

--- a/GalgameManager/Views/GalgameSettingPage.xaml
+++ b/GalgameManager/Views/GalgameSettingPage.xaml
@@ -34,10 +34,11 @@
                 </CommandBar>
 
                 <StackPanel Grid.Row="1" Spacing="25" Margin="{StaticResource MediumTopMargin}">
-                    <control:LockableSetting
+                    <control:LockableTextBox
                         x:Uid="GalgameSettingPage_GalgameName"
                         Value="{x:Bind ViewModel.Gal.Name.Value, Mode=TwoWay}"
-                        IsLock="{x:Bind ViewModel.Gal.Name.IsLock, Mode=TwoWay}" />
+                        IsLock="{x:Bind ViewModel.Gal.Name.IsLock, Mode=TwoWay}" 
+                        AcceptsReturn="False"/>
 
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -49,7 +50,7 @@
 
                         <StackPanel Orientation="Horizontal" Grid.Column="0">
                             <TextBlock x:Uid = "GalgameSettingPage_GalgameId" Margin="0 0 15 0" VerticalAlignment="Center"/>
-                            <TextBox Text="{x:Bind ViewModel.Gal.Id, Mode=TwoWay}"/>
+                            <TextBox Text="{x:Bind ViewModel.Gal.Id, Mode=TwoWay}" VerticalAlignment="Center" AcceptsReturn="False"/>
                         </StackPanel>
 
                         <Grid Grid.Column="1" Margin="50 0 0 0">
@@ -73,43 +74,47 @@
 
                         <StackPanel Grid.Column="2" Orientation="Horizontal" Margin="50 0 0 0">
                             <TextBlock x:Uid="GalgameSettingPage_GalgameSavePosition" Margin="0 0 15 0" VerticalAlignment="Center"/>
-                            <TextBox Text="{x:Bind ViewModel.Gal.SavePosition}" IsEnabled="False"/>
+                            <TextBox Text="{x:Bind ViewModel.Gal.SavePosition}" IsEnabled="False" VerticalAlignment="Center" AcceptsReturn="False"/>
                         </StackPanel>
 
-                        <control:LockableSetting 
+                        <control:LockableNumberBox 
                             Grid.Column="3" 
                             x:Uid="GalgameSettingPage_GalgameRating"
                             Value="{x:Bind ViewModel.Gal.Rating.Value, Mode=TwoWay}"
                             IsLock="{x:Bind ViewModel.Gal.Rating.IsLock, Mode=TwoWay}"
-                            Margin="50 0 0 0" />
+                            Margin="50 0 0 0"/>
                     </Grid>
 
-                    <control:LockableSetting 
+                    <control:LockableTextBox 
                         x:Uid="GalgameSettingPage_GalgameDeveloper"
                         Value="{x:Bind ViewModel.Gal.Developer.Value, Mode=TwoWay}"
-                        IsLock="{x:Bind ViewModel.Gal.Developer.IsLock, Mode=TwoWay}" />
+                        IsLock="{x:Bind ViewModel.Gal.Developer.IsLock, Mode=TwoWay}" 
+                        AcceptsReturn="False"/>
 
-                    <control:LockableSetting 
+                    <control:LockableTextBox 
                         x:Uid="GalgameSettingPage_GalgameExpectedPlayTime"
                         Value="{x:Bind ViewModel.Gal.ExpectedPlayTime.Value, Mode=TwoWay}"
-                        IsLock="{x:Bind ViewModel.Gal.ExpectedPlayTime.IsLock, Mode=TwoWay}" />
+                        IsLock="{x:Bind ViewModel.Gal.ExpectedPlayTime.IsLock, Mode=TwoWay}" 
+                        AcceptsReturn="False"/>
 
-                    <control:LockableSetting
+                    <control:LockableTextBox
                         x:Uid="GalgameSettingPage_GalgameDescription"
                         Value="{x:Bind ViewModel.Gal.Description.Value, Mode=TwoWay}"
-                        IsLock="{x:Bind ViewModel.Gal.Description.IsLock, Mode=TwoWay}" />
+                        IsLock="{x:Bind ViewModel.Gal.Description.IsLock, Mode=TwoWay}" 
+                        AcceptsReturn="True"/>
 
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <control:LockableSetting 
+                        <control:LockableTextBox 
                             Grid.Column="0"
                             x:Uid="GalgameSettingPage_GalgameImagePath"
                             Value="{x:Bind ViewModel.Gal.ImagePath.Value, Mode=TwoWay}"
                             IsLock="{x:Bind ViewModel.Gal.ImagePath.IsLock, Mode=TwoWay}"
-                            Readonly="True" />
+                            Readonly="True" 
+                            AcceptsReturn="False"/>
                         <Button Grid.Column="1" x:Uid="GalgameSettingPage_PickImage" Command="{x:Bind ViewModel.PickImageCommand}" Margin="10 0 0 0"/>
                     </Grid>
                 </StackPanel>


### PR DESCRIPTION
修复GalgameSettingPage设置不居中问题，将Rating替换为数字输入框
修复前:
![A](https://github.com/GoldenPotato137/PotatoVN/assets/47905372/1980e05a-bf13-4161-89ca-8d80174e304d)
修复后:
![B](https://github.com/GoldenPotato137/PotatoVN/assets/47905372/477efadc-03c9-4d93-99f6-32b45b838f03)

