### PR TITLE
对vndb获得的rating位数进行限制，防止出现过多小数位

### DIFF
--- a/GalgameManager/Helpers/Phrase/VndbPhraser.cs
+++ b/GalgameManager/Helpers/Phrase/VndbPhraser.cs
@@ -109,7 +109,7 @@ public class VndbPhraser : IGalInfoPhraser
             // id eg: v16044 -> 16044
             var id = rssItem.Id! ;
             result.Id = id.StartsWith("v")?id[1..]:id;
-            result.Rating = rssItem.Rating / 10 ?? 0;
+            result.Rating =(float)Math.Round(rssItem.Rating / 10 ?? 0.0D, 1);
             result.ExpectedPlayTime = GetLength(rssItem.Lenth,rssItem.LengthMinutes);
             result.ImageUrl = rssItem.Image != null ? rssItem.Image.Url! :"";
             // Developers


### PR DESCRIPTION
对vndb获得的rating位数进行限制，防止出现过多小数位