### PR TITLE
fix:vndb评分不能为0

### DIFF
--- a/GalgameManager/Helpers/Phrase/VndbPhraser.cs
+++ b/GalgameManager/Helpers/Phrase/VndbPhraser.cs
@@ -353,7 +353,7 @@ public class VndbPhraser : IGalInfoPhraser, IGalStatusSync, IGalCharacterPhraser
             {
                 LabelsSet = new List<int> {labelSet},
                 Notes = galgame.Comment,
-                Vote = galgame.MyRate * 10 // BgmRate: 0~10, VndbRate: 10~100, vndb的一个奇怪的点, 它网站上是 0~10
+                Vote = galgame.MyRate == 0 ? null : galgame.MyRate * 10 // BgmRate: 0~10, VndbRate: 10~100, vndb的一个奇怪的点, 它网站上是 0~10
                 // Vndb无private选项
             };
             if (tryGetResponse.Results?.Count == 1)


### PR DESCRIPTION
vndb评分是1-10，并且可以为null
![QQ20241224-010112](https://github.com/user-attachments/assets/cb51b2e3-7a46-49f1-9a57-9606f97c2ff8)

![QQ20241224-003127](https://github.com/user-attachments/assets/e10d5b0e-87ff-4e89-b555-05a1c81a0495)
