### PR TITLE
修正开关以及优先级判断

### DIFF
--- a/GalgameManager/Models/BgTasks/KeyMappingTask.cs
+++ b/GalgameManager/Models/BgTasks/KeyMappingTask.cs
@@ -137,20 +137,11 @@ public class KeyMappingTask : BgTaskBase
         {
             if (!mapping.IsEnabled || mapping.From.Count == 0 || mapping.To.Count == 0) continue;
 
-            var fromKeys = mapping.From.Select(k => (VirtualKey)k).ToList();
-            fromKeys.Sort((a, b) => GetKeyOrder(a) - GetKeyOrder(b));
-            var fromKeyString = string.Join("+", fromKeys.Select(GetKeyDisplayName));
-
-            // 检查是否包含鼠标按键
-            var mouseButton = mapping.To.FirstOrDefault(IsMouseButtonCode);
-            if (mouseButton != 0)
+            // 检查是否是鼠标到键盘的映射
+            var fromMouseButton = mapping.From.FirstOrDefault(IsMouseButtonCode);
+            if (fromMouseButton != 0)
             {
-                // 键盘映射到鼠标
-                _lookupMap[fromKeyString] = (new List<VirtualKeyCode>(), null, mouseButton);
-            }
-            else
-            {
-                // 键盘映射到键盘
+                // 鼠标映射到键盘
                 var toKeys = mapping.To.Select(k => (VirtualKey)k).ToList();
                 var toModifiers = toKeys.Where(IsModifierKey).Select(k => (VirtualKeyCode)k).ToList();
                 var toKey = toKeys.FirstOrDefault(k => !IsModifierKey(k));
@@ -158,7 +149,36 @@ public class KeyMappingTask : BgTaskBase
                 {
                     toKey = toKeys.FirstOrDefault();
                 }
+
+                var fromKeyString = $"Mouse{fromMouseButton}";
                 _lookupMap[fromKeyString] = (toModifiers, (VirtualKeyCode)toKey, null);
+            }
+            else
+            {
+                // 键盘映射（到键盘或鼠标）
+                var fromKeys = mapping.From.Select(k => (VirtualKey)k).ToList();
+                fromKeys.Sort((a, b) => GetKeyOrder(a) - GetKeyOrder(b));
+                var fromKeyString = string.Join("+", fromKeys.Select(GetKeyDisplayName));
+
+                // 检查是否包含鼠标按键
+                var mouseButton = mapping.To.FirstOrDefault(IsMouseButtonCode);
+                if (mouseButton != 0)
+                {
+                    // 键盘映射到鼠标
+                    _lookupMap[fromKeyString] = (new List<VirtualKeyCode>(), null, mouseButton);
+                }
+                else
+                {
+                    // 键盘映射到键盘
+                    var toKeys = mapping.To.Select(k => (VirtualKey)k).ToList();
+                    var toModifiers = toKeys.Where(IsModifierKey).Select(k => (VirtualKeyCode)k).ToList();
+                    var toKey = toKeys.FirstOrDefault(k => !IsModifierKey(k));
+                    if (toKey == default)
+                    {
+                        toKey = toKeys.FirstOrDefault();
+                    }
+                    _lookupMap[fromKeyString] = (toModifiers, (VirtualKeyCode)toKey, null);
+                }
             }
         }
     }
@@ -170,7 +190,8 @@ public class KeyMappingTask : BgTaskBase
         3 => true, // 鼠标中键
         4 => true, // X1按钮
         5 => true, // X2按钮
-        6 => true, // 鼠标滚轮
+        6 => true, // 鼠标滚轮向上
+        7 => true, // 鼠标滚轮向下
         _ => false
     };
 
@@ -249,13 +270,22 @@ public class KeyMappingTask : BgTaskBase
             if (_process.Id != foregroundProcessId) return CallNextHookEx(_mouseHookId, nCode, wParam, lParam);
 
             // 检查是否是需要处理的鼠标事件
-            if (!IsMouseButtonDownEvent(wParam)) return CallNextHookEx(_mouseHookId, nCode, wParam, lParam);
+            if (!IsMouseEvent(wParam)) return CallNextHookEx(_mouseHookId, nCode, wParam, lParam);
 
-            var mouseButton = GetMouseButtonFromWParam(wParam);
+            var mouseButton = GetMouseButtonFromWParam(wParam, lParam);
             if (mouseButton == 0) return CallNextHookEx(_mouseHookId, nCode, wParam, lParam);
 
-            // 这里可以处理鼠标到键盘的映射（如果需要的话）
-            // 目前我们只支持键盘到鼠标的映射
+            // 处理鼠标到键盘的映射
+            var fromKeyString = $"Mouse{mouseButton}";
+            if (_lookupMap.TryGetValue(fromKeyString, out var toHotkey))
+            {
+                if (toHotkey.key.HasValue)
+                {
+                    // 鼠标映射到键盘按键
+                    _inputSimulator.Keyboard.ModifiedKeyStroke(toHotkey.modifiers, toHotkey.key.Value);
+                }
+                return 1; // 阻止原始鼠标事件
+            }
         }
         catch(Exception)
         {
@@ -282,26 +312,44 @@ public class KeyMappingTask : BgTaskBase
                 mouse_event(MOUSEEVENTF_XDOWN, 0, 0, (uint)(mouseButton == 4 ? 1 : 2), 0);
                 mouse_event(MOUSEEVENTF_XUP, 0, 0, (uint)(mouseButton == 4 ? 1 : 2), 0);
                 break;
-            case 6: // 鼠标滚轮
-                mouse_event(MOUSEEVENTF_WHEEL, 0, 0, 120, 0); // 向上滚动
+            case 6: // 鼠标滚轮向上
+                mouse_event(MOUSEEVENTF_WHEEL, 0, 0, 120, 0);
+                break;
+            case 7: // 鼠标滚轮向下
+                mouse_event(MOUSEEVENTF_WHEEL, 0, 0, unchecked((uint)-120), 0);
                 break;
         }
     }
 
-    private static bool IsMouseButtonDownEvent(nint wParam) => wParam switch
+    private static bool IsMouseEvent(nint wParam) => wParam switch
     {
-        WM_LBUTTONDOWN or WM_RBUTTONDOWN or WM_MBUTTONDOWN or WM_XBUTTONDOWN => true,
+        WM_LBUTTONDOWN or WM_RBUTTONDOWN or WM_MBUTTONDOWN or WM_XBUTTONDOWN or WM_MOUSEWHEEL => true,
         _ => false
     };
 
-    private static int GetMouseButtonFromWParam(nint wParam) => wParam switch
+    private static int GetMouseButtonFromWParam(nint wParam, nint lParam) => wParam switch
     {
         WM_LBUTTONDOWN => 1,
         WM_RBUTTONDOWN => 2,
         WM_MBUTTONDOWN => 3,
-        WM_XBUTTONDOWN => 4, // 默认X1，需要读取额外数据确定X1/X2
+        WM_XBUTTONDOWN => GetXButtonFromLParam(lParam), // 读取额外数据确定X1/X2
+        WM_MOUSEWHEEL => GetWheelDirectionFromLParam(lParam), // 确定滚轮方向
         _ => 0
     };
+
+    private static int GetXButtonFromLParam(nint lParam)
+    {
+        // 高位字表示X按钮编号
+        var hiWord = (ushort)((uint)Marshal.ReadInt32(lParam) >> 16);
+        return hiWord == 1 ? 4 : 5; // X1=4, X2=5
+    }
+
+    private static int GetWheelDirectionFromLParam(nint lParam)
+    {
+        // 高位字表示滚轮方向
+        var hiWord = (short)((uint)Marshal.ReadInt32(lParam) >> 16);
+        return hiWord > 0 ? 6 : 7; // 向上=6, 向下=7
+    }
     
     private bool IsKeyDown(VirtualKey key) => (GetKeyState((int)key) & 0x8000) != 0;
 

--- a/GalgameManager/ViewModels/GalgameSettingViewModel.cs
+++ b/GalgameManager/ViewModels/GalgameSettingViewModel.cs
@@ -88,51 +88,35 @@ public partial class GalgameSettingViewModel : ObservableObject, INavigationAwar
             Gal = galgame;
             KeyMappings = new ObservableCollection<KeyMapping>();
 
-        // 先导入全局快捷键到最前面，但需要与用户自定义设置进行智能合并
-            List<KeyMapping> globalMappings = await GetGlobalKeyMappingsAsync();
+            // 用户设置优先：先导入用户的快捷键设置
             List<KeyMapping> userMappings = Gal.KeyMappings.ToList();
+            List<KeyMapping> globalMappings = await GetGlobalKeyMappingsAsync();
 
+            // 先添加用户的所有快捷键设置
+            foreach (var userMapping in userMappings)
+            {
+                KeyMappings.Add(userMapping);
+            }
+
+            // 然后处理全局快捷键，只添加用户没有定义的
             foreach (KeyMapping globalMapping in globalMappings)
             {
-                // 查找用户是否有基于这个全局快捷键的自定义映射（通过From键匹配）
-                var userMapping = userMappings.FirstOrDefault(um =>
+                // 检查用户是否已经定义了这个按键（通过From键匹配）
+                var hasUserMapping = userMappings.Any(um =>
                     um.From != null && globalMapping.From != null &&
                     um.From.SequenceEqual(globalMapping.From));
 
-                if (userMapping != null)
+                if (!hasUserMapping)
                 {
-                    // 用户有自定义映射，使用用户的设置（包含From和To），但保持IsGlobal标记
-                    KeyMappings.Add(new KeyMapping
-                    {
-                        From = new List<int>(userMapping.From),
-                        To = userMapping.To != null ? new List<int>(userMapping.To) : new List<int>(),
-                        Remark = globalMapping.Remark, // 保持全局的描述
-                        IsGlobal = true,
-                        IsEnabled = userMapping.IsEnabled
-                    });
-                }
-                else if (IsGlobalKeyMappingNotExists(globalMapping))
-                {
-                    // 用户没有自定义映射，使用全局设置
-                    KeyMappings.Add(new KeyMapping
+                    // 用户没有定义这个按键，添加全局设置到头部
+                    KeyMappings.Insert(0, new KeyMapping
                     {
                         From = new List<int>(globalMapping.From),
+                        To = globalMapping.To != null ? new List<int>(globalMapping.To) : new List<int>(),
                         Remark = globalMapping.Remark,
-                        IsGlobal = true
+                        IsGlobal = true,
+                        IsEnabled = true
                     });
-                }
-            }
-
-            // 添加独立的游戏快捷键（不基于全局快捷键的）
-            foreach (var localMapping in userMappings)
-            {
-                var hasMatchingGlobal = globalMappings.Any(gm =>
-                    gm.From != null && localMapping.From != null &&
-                    gm.From.SequenceEqual(localMapping.From));
-
-                if (!hasMatchingGlobal)
-                {
-                    KeyMappings.Add(localMapping);
                 }
             }
 

--- a/GalgameManager/ViewModels/GalgameViewModel.cs
+++ b/GalgameManager/ViewModels/GalgameViewModel.cs
@@ -354,7 +354,7 @@ public partial class GalgameViewModel : ObservableObject, INavigationAware
                 _ = _bgTaskService.AddBgTask(new CallMagpieTask(Item, process));
             if (await _localSettingsService.ReadSettingAsync<bool>(KeyValues.AlwaysMuteInBackground) || Item.MuteInBackground)
                 _ = _bgTaskService.AddBgTask(new GameMuteTask(Item, process));
-            if ((await _localSettingsService.ReadSettingAsync<bool>(KeyValues.GlobalKeyMappings) || Item.KeyReMap) && Item.KeyMappings.Any(m => m.IsEnabled))
+            if ((await _localSettingsService.ReadSettingAsync<bool>(KeyValues.GameReMapEnabled) || Item.KeyReMap) && Item.KeyMappings.Any(m => m.IsEnabled))
                 _ = _bgTaskService.AddBgTask(new KeyMappingTask(Item, process));
             if(process.HasExited == false)
                 App.SetWindowMode(await _localSettingsService.ReadSettingAsync<WindowMode>(KeyValues.PlayingWindowMode));

--- a/GalgameManager/ViewModels/GalgameViewModel.cs
+++ b/GalgameManager/ViewModels/GalgameViewModel.cs
@@ -354,7 +354,7 @@ public partial class GalgameViewModel : ObservableObject, INavigationAware
                 _ = _bgTaskService.AddBgTask(new CallMagpieTask(Item, process));
             if (await _localSettingsService.ReadSettingAsync<bool>(KeyValues.AlwaysMuteInBackground) || Item.MuteInBackground)
                 _ = _bgTaskService.AddBgTask(new GameMuteTask(Item, process));
-            if (Item.KeyMappings.Any(m => m.IsEnabled) && Item.KeyReMap)
+            if ((await _localSettingsService.ReadSettingAsync<bool>(KeyValues.GlobalKeyMappings) || Item.KeyReMap) && Item.KeyMappings.Any(m => m.IsEnabled))
                 _ = _bgTaskService.AddBgTask(new KeyMappingTask(Item, process));
             if(process.HasExited == false)
                 App.SetWindowMode(await _localSettingsService.ReadSettingAsync<WindowMode>(KeyValues.PlayingWindowMode));

--- a/GalgameManager/Views/Control/FlexibleHotkeyInputBox.xaml.cs
+++ b/GalgameManager/Views/Control/FlexibleHotkeyInputBox.xaml.cs
@@ -179,7 +179,9 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
 
         if (properties.MouseWheelDelta != 0)
         {
-            _mouseButtons.Add(6);
+            // 区分滚轮方向：向上为6，向下为7
+            var wheelCode = properties.MouseWheelDelta > 0 ? 6 : 7;
+            _mouseButtons.Add(wheelCode);
             CompleteCapture();
         }
     }
@@ -393,7 +395,7 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
     // 辅助方法
     private static bool IsMouseKeyCode(int keyCode) => keyCode switch
     {
-        >= 1 and <= 6 => true, // 鼠标按键
+        >= 1 and <= 7 => true, // 鼠标按键（包括滚轮上下6,7）
         _ => false
     };
 
@@ -404,7 +406,8 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
         3 => "MOUSE_MIDDLE",
         4 => "MOUSE_X1",
         5 => "MOUSE_X2",
-        6 => "MOUSE_WHEEL",
+        6 => "WHEEL_UP",
+        7 => "WHEEL_DOWN",
         _ => "MOUSE_UNKNOWN"
     };
 }

--- a/GalgameManager/Views/Dialog/KeyMappingDialog.xaml
+++ b/GalgameManager/Views/Dialog/KeyMappingDialog.xaml
@@ -109,8 +109,7 @@
                                               BorderThickness="0"
                                               HorizontalAlignment="Center"
                                               Padding="3"
-                                              Width="30" Height="30"
-                                              IsEnabled="{x:Bind IsGlobal, Converter={StaticResource InverseBooleanConverter}}">
+                                              Width="30" Height="30">
                                             <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE74D;" FontSize="14"/>
                                         </Button>
                                     </Grid>

--- a/GalgameManager/Views/Dialog/KeyMappingDialog.xaml.cs
+++ b/GalgameManager/Views/Dialog/KeyMappingDialog.xaml.cs
@@ -29,7 +29,7 @@ public sealed partial class KeyMappingDialog : ContentDialog
 
     private void RemoveKeyMapping(KeyMapping? mapping)
     {
-        if (mapping != null && !mapping.IsGlobal) // 只允许删除非全局快捷键
+        if (mapping != null) // 允许删除所有快捷键，包括全局快捷键
         {
             ViewModel.KeyMappings.Remove(mapping);
         }


### PR DESCRIPTION
dalao好快的合，个人对c#不熟的啊😂

1.  修改了开关的优先级判断，和全局静音等逻辑一致，(全局打开 || 游戏个别设置打开) ，之前只能游戏个别设置开启
2. 游戏内快捷键优先级比全局更高，意味着哪怕全局有设置了，在个别游戏界面中也可以删除

下面是一些使用说明

### 全局设置中可以设置全局快捷键，这个会在个别游戏设置中自动导入

<img width="1598" height="816" alt="image" src="https://github.com/user-attachments/assets/80331ee7-e6e6-4eb0-90ca-9c71f2d98ef2" />

### 如果不想自动导入全局设置，可以在这启动单个游戏的映射开关和设置
<img width="938" height="882" alt="image" src="https://github.com/user-attachments/assets/c0aef018-fb0a-4151-abf1-e6699ec12ae2" />

### 游戏编辑中可以编辑快捷键映射，如果`游戏中按键`是未设置状态，那么也不会影响按键本身的功能
<img width="1607" height="840" alt="image" src="https://github.com/user-attachments/assets/f13bc350-9d36-4d71-bf98-bda110bc7cc7" />

映射目前只支持单个 也就是1对1映射
目前支持
1. 键盘->鼠标
2. 键盘->键盘
3. 鼠标->键盘
