### PR TITLE
按键名称添加快速输入，增加列表选择模式

### DIFF
--- a/GalgameManager/Enums/HotkeyResourceKeys.cs
+++ b/GalgameManager/Enums/HotkeyResourceKeys.cs
@@ -1,0 +1,26 @@
+namespace GalgameManager.Enums;
+
+public static class HotkeyResourceKeys
+{
+    public const string Prefix = "Galgame_hotkey_common_";
+
+    public static readonly string[] KnownKeys = new[]
+    {
+        "QuickSave",
+        "QuickLoad",
+        "Save",
+        "Load",
+        "AutoSave",
+        "Fullscreen",
+        "Windowed",
+        "Settings",
+        "Exit",
+        "Menu",
+        "Skip",
+        "FastForward",
+        "Rewind",
+        "Select",
+        "Confirm",
+        "Cancel"
+    };
+}

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -3281,6 +3281,9 @@ If play time can record correctly, just cancel this popup.
   <data name="GlobalKeyMappingDialog_Button_Cancel" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="KeyMapping_Info_KeyMappingSaved" xml:space="preserve">
+    <value>Key mapping saved</value>
+  </data>
   <data name="GlobalKeyMappingDialog_Text_NoMappings.Text" xml:space="preserve">
     <value>No key mappings available</value>
   </data>

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -3392,4 +3392,55 @@ If play time can record correctly, just cancel this popup.
   <data name="UploadAllPlayStatusTask_Progress_Waiting" xml:space="preserve">
     <value>Waiting to upload {0} items</value>
   </data>
+
+  <!-- ========== SearchableTextBox 常用热键建议 ========== -->
+  <data name="Galgame_hotkey_common_QuickSave" xml:space="preserve">
+    <value>Quick Save</value>
+  </data>
+  <data name="Galgame_hotkey_common_QuickLoad" xml:space="preserve">
+    <value>Quick Load</value>
+  </data>
+  <data name="Galgame_hotkey_common_Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Galgame_hotkey_common_Load" xml:space="preserve">
+    <value>Load</value>
+  </data>
+  <data name="Galgame_hotkey_common_AutoSave" xml:space="preserve">
+    <value>Auto Save</value>
+  </data>
+  <data name="Galgame_hotkey_common_Fullscreen" xml:space="preserve">
+    <value>Fullscreen</value>
+  </data>
+  <data name="Galgame_hotkey_common_Windowed" xml:space="preserve">
+    <value>Windowed</value>
+  </data>
+  <data name="Galgame_hotkey_common_Settings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="Galgame_hotkey_common_Exit" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="Galgame_hotkey_common_Menu" xml:space="preserve">
+    <value>Menu</value>
+  </data>
+  <data name="Galgame_hotkey_common_Skip" xml:space="preserve">
+    <value>Skip</value>
+  </data>
+  <data name="Galgame_hotkey_common_FastForward" xml:space="preserve">
+    <value>Fast Forward</value>
+  </data>
+  <data name="Galgame_hotkey_common_Rewind" xml:space="preserve">
+    <value>Rewind</value>
+  </data>
+  <data name="Galgame_hotkey_common_Select" xml:space="preserve">
+    <value>Select</value>
+  </data>
+  <data name="Galgame_hotkey_common_Confirm" xml:space="preserve">
+    <value>Confirm</value>
+  </data>
+  <data name="Galgame_hotkey_common_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+
 </root>

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -3265,7 +3265,6 @@ If play time can record correctly, just cancel this popup.
   <data name="KeyMappingDialog_InputModeToggle.OnContent" xml:space="preserve">
     <value>Selection Mode</value>
   </data>
-
   <data name="GlobalKeyMappingDialog_Title" xml:space="preserve">
     <value>Global Key Mapping Settings</value>
   </data>
@@ -3392,8 +3391,6 @@ If play time can record correctly, just cancel this popup.
   <data name="UploadAllPlayStatusTask_Progress_Waiting" xml:space="preserve">
     <value>Waiting to upload {0} items</value>
   </data>
-
-  <!-- ========== SearchableTextBox 常用热键建议 ========== -->
   <data name="Galgame_hotkey_common_QuickSave" xml:space="preserve">
     <value>Quick Save</value>
   </data>

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -3256,6 +3256,16 @@ If play time can record correctly, just cancel this popup.
   <data name="KeyMappingDialog_Placeholder_PressKey" xml:space="preserve">
     <value>Press a key or mouse button</value>
   </data>
+  <data name="KeyMappingDialog_InputMode.Text" xml:space="preserve">
+    <value>Input Mode:</value>
+  </data>
+  <data name="KeyMappingDialog_InputModeToggle.OffContent" xml:space="preserve">
+    <value>Capture Mode</value>
+  </data>
+  <data name="KeyMappingDialog_InputModeToggle.OnContent" xml:space="preserve">
+    <value>Selection Mode</value>
+  </data>
+
   <data name="GlobalKeyMappingDialog_Title" xml:space="preserve">
     <value>Global Key Mapping Settings</value>
   </data>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -3245,6 +3245,9 @@
   <data name="GlobalKeyMappingDialog_Button_Cancel" xml:space="preserve">
     <value>キャンセル</value>
   </data>
+  <data name="KeyMapping_Info_KeyMappingSaved" xml:space="preserve">
+    <value>キーマッピングが保存されました</value>
+  </data>
   <data name="GlobalKeyMappingDialog_Text_NoMappings.Text" xml:space="preserve">
     <value>キーマッピングがありません</value>
   </data>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -3319,14 +3319,13 @@
   </data>
   <data name="Settings_Game_ReMapEnabled.Title" xml:space="preserve">
     <value>ゲームキーマッピングを有効化</value>
+  </data>
   <data name="Settings_Game_ReMapEnabled.Description" xml:space="preserve">
     <value>ゲームキーマッピングのグローバルスイッチ。</value>
   </data>
   <data name="Settings_Game_EditKeyMapping.Text" xml:space="preserve">
     <value>キーマッピング編集</value>
   </data>
-
-  <!-- ========== SearchableTextBox 常用热键建议 ========== -->
   <data name="Galgame_hotkey_common_QuickSave" xml:space="preserve">
     <value>クイックセーブ</value>
   </data>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -3221,6 +3221,15 @@
   <data name="KeyMappingDialog_Placeholder_PressKey" xml:space="preserve">
     <value>キーまたはマウスボタンを押してください</value>
   </data>
+  <data name="KeyMappingDialog_InputMode.Text" xml:space="preserve">
+    <value>入力モード:</value>
+  </data>
+  <data name="KeyMappingDialog_InputModeToggle.OffContent" xml:space="preserve">
+    <value>キャプチャモード</value>
+  </data>
+  <data name="KeyMappingDialog_InputModeToggle.OnContent" xml:space="preserve">
+    <value>選択モード</value>
+  </data>
   <data name="GlobalKeyMappingDialog_Title" xml:space="preserve">
     <value>グローバルキーマッピング設定</value>
   </data>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -3319,11 +3319,61 @@
   </data>
   <data name="Settings_Game_ReMapEnabled.Title" xml:space="preserve">
     <value>ゲームキーマッピングを有効化</value>
-  </data>
   <data name="Settings_Game_ReMapEnabled.Description" xml:space="preserve">
     <value>ゲームキーマッピングのグローバルスイッチ。</value>
   </data>
   <data name="Settings_Game_EditKeyMapping.Text" xml:space="preserve">
     <value>キーマッピング編集</value>
   </data>
+
+  <!-- ========== SearchableTextBox 常用热键建议 ========== -->
+  <data name="Galgame_hotkey_common_QuickSave" xml:space="preserve">
+    <value>クイックセーブ</value>
+  </data>
+  <data name="Galgame_hotkey_common_QuickLoad" xml:space="preserve">
+    <value>クイックロード</value>
+  </data>
+  <data name="Galgame_hotkey_common_Save" xml:space="preserve">
+    <value>セーブ</value>
+  </data>
+  <data name="Galgame_hotkey_common_Load" xml:space="preserve">
+    <value>ロード</value>
+  </data>
+  <data name="Galgame_hotkey_common_AutoSave" xml:space="preserve">
+    <value>オートセーブ</value>
+  </data>
+  <data name="Galgame_hotkey_common_Fullscreen" xml:space="preserve">
+    <value>フルスクリーン</value>
+  </data>
+  <data name="Galgame_hotkey_common_Windowed" xml:space="preserve">
+    <value>ウィンドウモード</value>
+  </data>
+  <data name="Galgame_hotkey_common_Settings" xml:space="preserve">
+    <value>設定</value>
+  </data>
+  <data name="Galgame_hotkey_common_Exit" xml:space="preserve">
+    <value>終了</value>
+  </data>
+  <data name="Galgame_hotkey_common_Menu" xml:space="preserve">
+    <value>メニュー</value>
+  </data>
+  <data name="Galgame_hotkey_common_Skip" xml:space="preserve">
+    <value>スキップ</value>
+  </data>
+  <data name="Galgame_hotkey_common_FastForward" xml:space="preserve">
+    <value>早送り</value>
+  </data>
+  <data name="Galgame_hotkey_common_Rewind" xml:space="preserve">
+    <value>巻き戻し</value>
+  </data>
+  <data name="Galgame_hotkey_common_Select" xml:space="preserve">
+    <value>選択</value>
+  </data>
+  <data name="Galgame_hotkey_common_Confirm" xml:space="preserve">
+    <value>決定</value>
+  </data>
+  <data name="Galgame_hotkey_common_Cancel" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -3946,6 +3946,10 @@
   <data name="GlobalKeyMappingDialog_Text_NoMappings.Text" xml:space="preserve">
     <value>暂无按键映射</value>
   </data>
+  <data name="KeyMapping_Info_KeyMappingSaved" xml:space="preserve">
+    <value>按键映射已保存</value>
+  </data>
+
   <data name="SettingsPage_Game_GlobalKeyMapping.Title" xml:space="preserve">
     <value>全局按键映射</value>
   </data>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -3919,6 +3919,15 @@
   <data name="KeyMappingDialog_Placeholder_PressKey" xml:space="preserve">
     <value>请按下快捷键或鼠标按键</value>
   </data>
+  <data name="KeyMappingDialog_InputMode.Text" xml:space="preserve">
+    <value>输入模式:</value>
+  </data>
+  <data name="KeyMappingDialog_InputModeToggle.OffContent" xml:space="preserve">
+    <value>捕获模式</value>
+  </data>
+  <data name="KeyMappingDialog_InputModeToggle.OnContent" xml:space="preserve">
+    <value>选择模式</value>
+  </data>
   <data name="GlobalKeyMappingDialog_Title" xml:space="preserve">
     <value>全局按键映射设置</value>
   </data>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -4018,7 +4018,7 @@
   </data>
   <data name="Settings_Game_ReMapEnabled.Title" xml:space="preserve">
     <value>启动游戏快捷键映射</value>
-  </data>
+data>
   <data name="Settings_Game_ReMapEnabled.Description" xml:space="preserve">
     <value>游戏快捷键映射总开关。</value>
   </data>
@@ -4055,4 +4055,55 @@
   <data name="UploadAllPlayStatusTask_Progress_Waiting" xml:space="preserve">
     <value>等待上传 {0} 条记录</value>
   </data>
+
+  <!-- ========== SearchableTextBox 常用热键建议 ========== -->
+  <data name="Galgame_hotkey_common_QuickSave" xml:space="preserve">
+    <value>快速保存</value>
+  </data>
+  <data name="Galgame_hotkey_common_QuickLoad" xml:space="preserve">
+    <value>快速加载</value>
+  </data>
+  <data name="Galgame_hotkey_common_Save" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="Galgame_hotkey_common_Load" xml:space="preserve">
+    <value>加载</value>
+  </data>
+  <data name="Galgame_hotkey_common_AutoSave" xml:space="preserve">
+    <value>自动保存</value>
+  </data>
+  <data name="Galgame_hotkey_common_Fullscreen" xml:space="preserve">
+    <value>全屏</value>
+  </data>
+  <data name="Galgame_hotkey_common_Windowed" xml:space="preserve">
+    <value>窗口化</value>
+  </data>
+  <data name="Galgame_hotkey_common_Settings" xml:space="preserve">
+    <value>设置</value>
+  </data>
+  <data name="Galgame_hotkey_common_Exit" xml:space="preserve">
+    <value>退出</value>
+  </data>
+  <data name="Galgame_hotkey_common_Menu" xml:space="preserve">
+    <value>菜单</value>
+  </data>
+  <data name="Galgame_hotkey_common_Skip" xml:space="preserve">
+    <value>跳过</value>
+  </data>
+  <data name="Galgame_hotkey_common_FastForward" xml:space="preserve">
+    <value>快进</value>
+  </data>
+  <data name="Galgame_hotkey_common_Rewind" xml:space="preserve">
+    <value>回退</value>
+  </data>
+  <data name="Galgame_hotkey_common_Select" xml:space="preserve">
+    <value>选择</value>
+  </data>
+  <data name="Galgame_hotkey_common_Confirm" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="Galgame_hotkey_common_Cancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
+
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -3949,7 +3949,6 @@
   <data name="KeyMapping_Info_KeyMappingSaved" xml:space="preserve">
     <value>按键映射已保存</value>
   </data>
-
   <data name="SettingsPage_Game_GlobalKeyMapping.Title" xml:space="preserve">
     <value>全局按键映射</value>
   </data>
@@ -4018,7 +4017,7 @@
   </data>
   <data name="Settings_Game_ReMapEnabled.Title" xml:space="preserve">
     <value>启动游戏快捷键映射</value>
-data>
+  </data>
   <data name="Settings_Game_ReMapEnabled.Description" xml:space="preserve">
     <value>游戏快捷键映射总开关。</value>
   </data>
@@ -4055,8 +4054,6 @@ data>
   <data name="UploadAllPlayStatusTask_Progress_Waiting" xml:space="preserve">
     <value>等待上传 {0} 条记录</value>
   </data>
-
-  <!-- ========== SearchableTextBox 常用热键建议 ========== -->
   <data name="Galgame_hotkey_common_QuickSave" xml:space="preserve">
     <value>快速保存</value>
   </data>

--- a/GalgameManager/ViewModels/GalgameSettingViewModel.cs
+++ b/GalgameManager/ViewModels/GalgameSettingViewModel.cs
@@ -308,7 +308,15 @@ public partial class GalgameSettingViewModel : ObservableObject, INavigationAwar
             XamlRoot = App.MainWindow!.Content.XamlRoot,
             RequestedTheme = App.MainWindow.Content is FrameworkElement element ? element.RequestedTheme : ElementTheme.Default
         };
-        await dialog.ShowAsync();
+
+        ContentDialogResult result = await dialog.ShowAsync();
+
+        // 只有在用户点击保存时才保存设置并显示通知
+        if (result == ContentDialogResult.Primary)
+        {
+            await SaveKeyMappingsAsync();
+            _infoService.Info(InfoBarSeverity.Success, msg:"KeyMapping_Info_KeyMappingSaved".GetLocalized(), displayTimeMs: 2000);
+        }
     }
 
   

--- a/GalgameManager/Views/Control/FlexibleHotkeyInputBox.xaml
+++ b/GalgameManager/Views/Control/FlexibleHotkeyInputBox.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="using:GalgameManager.Views.Control"
     mc:Ignorable="d">
 
     <Border Background="{ThemeResource TextControlBackground}"
@@ -13,6 +14,7 @@
             MinHeight="32"
             Padding="11,5,11,6">
         <Grid>
+            <!-- 背景文本层 -->
             <TextBlock x:Name="PlaceholderTextBlock"
                        Text="{x:Bind PlaceholderText, Mode=OneWay}"
                        Foreground="{ThemeResource TextControlPlaceholderForeground}"
@@ -27,20 +29,47 @@
                        VerticalAlignment="Center"
                        IsHitTestVisible="False" />
 
-            <Button x:Name="InputButton"
-                    Background="Transparent"
-                    BorderThickness="0"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    HorizontalContentAlignment="Left"
-                    VerticalContentAlignment="Center"
-                    Padding="0"
-                    Click="InputButton_Click"
-                    KeyDown="InputButton_KeyDown"
-                    PointerPressed="InputButton_PointerPressed"
-                    PointerWheelChanged="InputButton_PointerWheelChanged"
-                    LostFocus="InputButton_LostFocus"
-                    Content="{x:Bind ButtonText, Mode=OneWay}" />
+            <!-- 交互层 -->
+            <Grid>
+                <!-- 捕获模式按钮 -->
+                <Button x:Name="InputButton"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        HorizontalContentAlignment="Left"
+                        VerticalContentAlignment="Center"
+                        Padding="0"
+                        Click="InputButton_Click"
+                        KeyDown="InputButton_KeyDown"
+                        PointerPressed="InputButton_PointerPressed"
+                        PointerWheelChanged="InputButton_PointerWheelChanged"
+                        LostFocus="InputButton_LostFocus"
+                        Content="{x:Bind ButtonText, Mode=OneWay}"
+                        Visibility="{x:Bind CaptureButtonVisibility, Mode=OneWay}" />
+
+                <!-- 选择模式下拉框 -->
+                <ComboBox x:Name="KeyDropdown"
+                          ItemsSource="{x:Bind DropdownOptions, Mode=OneWay}"
+                          Visibility="{x:Bind DropdownVisibility, Mode=OneWay}"
+                          SelectionChanged="OnDropdownSelectionChanged"
+                          IsEditable="False"
+                          HorizontalAlignment="Stretch"
+                          VerticalAlignment="Center"
+                          Background="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          Margin="-11,-7,-11,-6">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="local:HotkeyOption">
+                            <TextBlock Text="{Binding DisplayName}"
+                                       Foreground="{ThemeResource TextControlForeground}"
+                                       VerticalAlignment="Center"
+                                       Margin="8,2" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </Grid>
         </Grid>
     </Border>
 </UserControl>

--- a/GalgameManager/Views/Control/FlexibleHotkeyInputBox.xaml.cs
+++ b/GalgameManager/Views/Control/FlexibleHotkeyInputBox.xaml.cs
@@ -3,9 +3,16 @@ using System.Runtime.CompilerServices;
 using Windows.System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Controls;
 using CommunityToolkit.WinUI;
 
 namespace GalgameManager.Views.Control;
+
+public enum InputMode
+{
+    Capture,
+    Dropdown
+}
 
 public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
 {
@@ -17,11 +24,21 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
     private string _hotkeyDisplayText = "";
     private Visibility _showPlaceholder = Visibility.Visible;
     private Visibility _hideText = Visibility.Collapsed;
+    private Visibility _captureButtonVisibility = Visibility.Visible;
+    private Visibility _dropdownVisibility = Visibility.Collapsed;
 
     public FlexibleHotkeyInputBox()
     {
         InitializeComponent();
         UpdateButtonText();
+
+        // 延迟初始化模式显示，确保控件完全加载
+        Loaded += (sender, e) =>
+        {
+            // 初始时默认为捕获模式
+            InputMode = InputMode.Capture;
+            UpdateDisplay();
+        };
     }
 
     public static readonly DependencyProperty PlaceholderTextProperty =
@@ -44,11 +61,40 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
         set => SetValue(HotkeyKeysProperty, value);
     }
 
+    public static readonly DependencyProperty InputModeProperty =
+        DependencyProperty.Register(nameof(InputMode), typeof(InputMode), typeof(FlexibleHotkeyInputBox),
+            new PropertyMetadata(InputMode.Capture, OnInputModeChanged));
+
+    public InputMode InputMode
+    {
+        get => (InputMode)GetValue(InputModeProperty);
+        set => SetValue(InputModeProperty, value);
+    }
+
+    private static void OnInputModeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is FlexibleHotkeyInputBox control)
+        {
+            control.UpdateModeDisplay();
+        }
+    }
+
     private static void OnHotkeyKeysChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is FlexibleHotkeyInputBox control)
         {
-            control.UpdateDisplay();
+            // 根据当前模式更新显示
+            if (control.InputMode == InputMode.Dropdown)
+            {
+                // 在下拉模式下，先更新选择，然后更新显示文本
+                control.UpdateDropdownSelection();
+                control.UpdateDisplay();
+            }
+            else
+            {
+                // 在捕获模式下，正常更新显示
+                control.UpdateDisplay();
+            }
         }
     }
 
@@ -92,7 +138,27 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
         }
     }
 
-    
+    public Visibility CaptureButtonVisibility
+    {
+        get => _captureButtonVisibility;
+        private set
+        {
+            _captureButtonVisibility = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public Visibility DropdownVisibility
+    {
+        get => _dropdownVisibility;
+        private set
+        {
+            _dropdownVisibility = value;
+            OnPropertyChanged();
+        }
+    }
+
+
     public event PropertyChangedEventHandler? PropertyChanged;
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
@@ -205,7 +271,7 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
         _isCapturing = true;
         _pressedKeys.Clear();
         _mouseButtons.Clear();
-        ButtonText = "请按下快捷键或鼠标按键";
+        ButtonText = "KeyMappingDialog_Placeholder_PressKey".GetLocalized() ?? "请按下快捷键或鼠标按键";
         ShowPlaceholder = Visibility.Collapsed;
         HideText = Visibility.Collapsed;
         InputButton.Focus(FocusState.Programmatic);
@@ -306,8 +372,17 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
                 ShowPlaceholder = Visibility.Collapsed;
                 HideText = Visibility.Collapsed;
             }
+            else if (InputMode == InputMode.Capture)
+            {
+                // 在捕获模式且非捕获状态下，显示在HotkeyDisplayText上
+                ButtonText = "";
+                HotkeyDisplayText = displayText;
+                ShowPlaceholder = Visibility.Collapsed;
+                HideText = Visibility.Visible;
+            }
             else
             {
+                // 在下拉模式下，只显示背景文本，避免重影
                 ButtonText = "";
                 HotkeyDisplayText = displayText;
                 ShowPlaceholder = Visibility.Collapsed;
@@ -322,7 +397,58 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
     {
         if (!_isCapturing && (HotkeyKeys.Count == 0))
         {
-            ButtonText = "点击设置快捷键";
+            ButtonText = "KeyMappingDialog_Placeholder_ClickToSet".GetLocalized() ?? "点击设置";
+        }
+    }
+
+    private void UpdateModeDisplay()
+    {
+        try
+        {
+            if (InputMode == InputMode.Dropdown)
+            {
+                CaptureButtonVisibility = Visibility.Collapsed;
+                DropdownVisibility = Visibility.Visible;
+
+                // 确保下拉列表已正确初始化
+                EnsureDropdownInitialized();
+
+                // 更新下拉选择，确保在有按键时正确显示
+                UpdateDropdownSelection();
+
+                // 根据是否有按键来设置显示文本
+                if (HotkeyKeys.Count > 0)
+                {
+                    ShowPlaceholder = Visibility.Collapsed;
+                    HideText = Visibility.Visible;
+                    ButtonText = "";
+
+                    // 更新显示，确保背景文本和下拉框文本都正确
+                    UpdateDisplay();
+                }
+                else
+                {
+                    ShowPlaceholder = Visibility.Visible;
+                    HideText = Visibility.Collapsed;
+                    ButtonText = "";
+                }
+            }
+            else
+            {
+                CaptureButtonVisibility = Visibility.Visible;
+                DropdownVisibility = Visibility.Collapsed;
+
+                // 更新显示，确保在有按键时正确显示
+                UpdateDisplay();
+            }
+        }
+        catch (Exception ex)
+        {
+            // 记录异常但不中断程序
+            System.Diagnostics.Debug.WriteLine($"UpdateModeDisplay error: {ex.Message}");
+            // 如果出错，默认回到捕获模式
+            CaptureButtonVisibility = Visibility.Visible;
+            DropdownVisibility = Visibility.Collapsed;
         }
     }
 
@@ -369,6 +495,29 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
             VirtualKey.Down => "↓",
             VirtualKey.Left => "←",
             VirtualKey.Right => "→",
+            // 数字键（主键盘）
+            VirtualKey.Number0 => "0",
+            VirtualKey.Number1 => "1",
+            VirtualKey.Number2 => "2",
+            VirtualKey.Number3 => "3",
+            VirtualKey.Number4 => "4",
+            VirtualKey.Number5 => "5",
+            VirtualKey.Number6 => "6",
+            VirtualKey.Number7 => "7",
+            VirtualKey.Number8 => "8",
+            VirtualKey.Number9 => "9",
+            // 数字小键盘
+            VirtualKey.NumberPad0 => "NumPad 0",
+            VirtualKey.NumberPad1 => "NumPad 1",
+            VirtualKey.NumberPad2 => "NumPad 2",
+            VirtualKey.NumberPad3 => "NumPad 3",
+            VirtualKey.NumberPad4 => "NumPad 4",
+            VirtualKey.NumberPad5 => "NumPad 5",
+            VirtualKey.NumberPad6 => "NumPad 6",
+            VirtualKey.NumberPad7 => "NumPad 7",
+            VirtualKey.NumberPad8 => "NumPad 8",
+            VirtualKey.NumberPad9 => "NumPad 9",
+            // 功能键
             VirtualKey.F1 => "F1",
             VirtualKey.F2 => "F2",
             VirtualKey.F3 => "F3",
@@ -381,6 +530,8 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
             VirtualKey.F10 => "F10",
             VirtualKey.F11 => "F11",
             VirtualKey.F12 => "F12",
+            // 字母键 - 单独处理以确保正确显示
+            >= VirtualKey.A and <= VirtualKey.Z => ((char)key).ToString(),
             _ => key.ToString()
         };
     }
@@ -392,6 +543,230 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
         HotkeyChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    // 获取下拉选项
+    public List<HotkeyOption> DropdownOptions => GetDropdownOptions();
+
+    private List<HotkeyOption> GetDropdownOptions()
+    {
+        var options = new List<HotkeyOption>();
+
+        // 修饰键
+        options.Add(new HotkeyOption("Win", (int)VirtualKey.LeftWindows));
+        options.Add(new HotkeyOption("Ctrl", (int)VirtualKey.Control));
+        options.Add(new HotkeyOption("Alt", (int)VirtualKey.Menu));
+        options.Add(new HotkeyOption("Shift", (int)VirtualKey.Shift));
+
+        // 功能键
+        for (var i = 1; i <= 12; i++) // 只到F12，更常见的功能键
+        {
+            var key = (VirtualKey)(111 + i); // F1-F12
+            if (Enum.IsDefined(typeof(VirtualKey), key))
+            {
+                options.Add(new HotkeyOption($"F{i}", (int)key));
+            }
+        }
+
+        // 数字键（主键盘）- 优先级最高
+        for (var i = 0; i < 10; i++)
+        {
+            var key = (VirtualKey)('0' + i);
+            options.Add(new HotkeyOption(((char)('0' + i)).ToString(), (int)key));
+        }
+
+        // 字母键
+        for (var i = 0; i < 26; i++)
+        {
+            var key = (VirtualKey)('A' + i);
+            options.Add(new HotkeyOption(((char)('A' + i)).ToString(), (int)key));
+        }
+
+        // 特殊键
+        options.Add(new HotkeyOption("Space", (int)VirtualKey.Space));
+        options.Add(new HotkeyOption("Tab", (int)VirtualKey.Tab));
+        options.Add(new HotkeyOption("Enter", (int)VirtualKey.Enter));
+        options.Add(new HotkeyOption("Esc", (int)VirtualKey.Escape));
+        options.Add(new HotkeyOption("Backspace", (int)VirtualKey.Back));
+        options.Add(new HotkeyOption("Delete", (int)VirtualKey.Delete));
+        options.Add(new HotkeyOption("Insert", (int)VirtualKey.Insert));
+        options.Add(new HotkeyOption("Home", (int)VirtualKey.Home));
+        options.Add(new HotkeyOption("End", (int)VirtualKey.End));
+        options.Add(new HotkeyOption("Page Up", (int)VirtualKey.PageUp));
+        options.Add(new HotkeyOption("Page Down", (int)VirtualKey.PageDown));
+        options.Add(new HotkeyOption("↑", (int)VirtualKey.Up));
+        options.Add(new HotkeyOption("↓", (int)VirtualKey.Down));
+        options.Add(new HotkeyOption("←", (int)VirtualKey.Left));
+        options.Add(new HotkeyOption("→", (int)VirtualKey.Right));
+
+        // 数字小键盘 - 优先级较低
+        options.Add(new HotkeyOption("NumPad 0", (int)VirtualKey.NumberPad0));
+        options.Add(new HotkeyOption("NumPad 1", (int)VirtualKey.NumberPad1));
+        options.Add(new HotkeyOption("NumPad 2", (int)VirtualKey.NumberPad2));
+        options.Add(new HotkeyOption("NumPad 3", (int)VirtualKey.NumberPad3));
+        options.Add(new HotkeyOption("NumPad 4", (int)VirtualKey.NumberPad4));
+        options.Add(new HotkeyOption("NumPad 5", (int)VirtualKey.NumberPad5));
+        options.Add(new HotkeyOption("NumPad 6", (int)VirtualKey.NumberPad6));
+        options.Add(new HotkeyOption("NumPad 7", (int)VirtualKey.NumberPad7));
+        options.Add(new HotkeyOption("NumPad 8", (int)VirtualKey.NumberPad8));
+        options.Add(new HotkeyOption("NumPad 9", (int)VirtualKey.NumberPad9));
+
+        // 鼠标按键
+        options.Add(new HotkeyOption("MOUSE_LEFT", 1));
+        options.Add(new HotkeyOption("MOUSE_RIGHT", 2));
+        options.Add(new HotkeyOption("MOUSE_MIDDLE", 3));
+        options.Add(new HotkeyOption("MOUSE_X1", 4));
+        options.Add(new HotkeyOption("MOUSE_X2", 5));
+        options.Add(new HotkeyOption("WHEEL_UP", 6));
+        options.Add(new HotkeyOption("WHEEL_DOWN", 7));
+
+        return options;
+    }
+
+    private void OnDropdownSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        try
+        {
+            if (sender is ComboBox comboBox && comboBox.SelectedItem is HotkeyOption selectedOption)
+            {
+                // 确保选择的选项有效且不是初始化过程
+                if (selectedOption.KeyCode >= 0 && InputMode == InputMode.Dropdown) // 有效按键码且在下拉模式下
+                {
+                    // 防止重复设置相同值
+                    if (HotkeyKeys.Count == 0 || HotkeyKeys[0] != selectedOption.KeyCode)
+                    {
+                        HotkeyKeys = new List<int> { selectedOption.KeyCode };
+                        OnHotkeyChanged();
+                        // 不需要手动调用UpdateDisplay，因为OnHotkeyKeysChanged会处理显示更新
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // 记录异常但不中断程序
+            System.Diagnostics.Debug.WriteLine($"OnDropdownSelectionChanged error: {ex.Message}");
+        }
+    }
+
+    private void UpdateDropdownSelection()
+    {
+        try
+        {
+            if (KeyDropdown != null && HotkeyKeys.Count > 0)
+            {
+                var firstKey = HotkeyKeys[0];
+                var matchingOption = DropdownOptions.FirstOrDefault(opt => opt.KeyCode == firstKey);
+
+                // 使用异步方式设置选择，确保UI已完全加载
+                KeyDropdown.DispatcherQueue.TryEnqueue(() =>
+                {
+                    try
+                    {
+                        // 临时移除事件处理器以防止触发不必要的事件
+                        KeyDropdown.SelectionChanged -= OnDropdownSelectionChanged;
+
+                        if (matchingOption != null)
+                        {
+                            // 确保在下拉列表中找到匹配项后再设置选择
+                            var itemIndex = DropdownOptions.IndexOf(matchingOption);
+                            if (itemIndex >= 0 && itemIndex < KeyDropdown.Items.Count)
+                            {
+                                KeyDropdown.SelectedIndex = itemIndex;
+                            }
+                            else
+                            {
+                                KeyDropdown.SelectedIndex = -1;
+                            }
+                        }
+                        else
+                        {
+                            // 如果没有找到匹配项，清除选择
+                            KeyDropdown.SelectedIndex = -1;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"UpdateDropdownSelection (inner) error: {ex.Message}");
+                    }
+                    finally
+                    {
+                        // 重新添加事件处理器
+                        KeyDropdown.SelectionChanged += OnDropdownSelectionChanged;
+                    }
+                });
+            }
+            else if (KeyDropdown != null)
+            {
+                // 如果没有按键，清除选择
+                KeyDropdown.DispatcherQueue.TryEnqueue(() =>
+                {
+                    try
+                    {
+                        KeyDropdown.SelectionChanged -= OnDropdownSelectionChanged;
+                        KeyDropdown.SelectedIndex = -1;
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"UpdateDropdownSelection (empty) error: {ex.Message}");
+                    }
+                    finally
+                    {
+                        KeyDropdown.SelectionChanged += OnDropdownSelectionChanged;
+                    }
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            // 记录异常但不中断程序
+            System.Diagnostics.Debug.WriteLine($"UpdateDropdownSelection error: {ex.Message}");
+        }
+    }
+
+    private string GetDisplayNameForKeyCode(int keyCode)
+    {
+        // 首先检查是否是鼠标按键
+        if (IsMouseKeyCode(keyCode))
+        {
+            return GetMouseDisplayName(keyCode);
+        }
+
+        // 然后检查是否是键盘按键
+        if (Enum.IsDefined(typeof(VirtualKey), keyCode))
+        {
+            var virtualKey = (VirtualKey)keyCode;
+            return GetKeyDisplayName(virtualKey);
+        }
+
+        // 如果都不匹配，返回未知
+        return $"Unknown Key ({keyCode})";
+    }
+
+    private void EnsureDropdownInitialized()
+    {
+        try
+        {
+            // 确保下拉列表已正确初始化
+            if (KeyDropdown != null && DropdownOptions.Count > 0)
+            {
+                // 强制刷新下拉列表项
+                KeyDropdown.ItemsSource = null;
+                KeyDropdown.ItemsSource = DropdownOptions;
+
+                // 确保没有默认选择
+                KeyDropdown.SelectedIndex = -1;
+
+                // 如果有现有按键，更新选择
+                UpdateDropdownSelection();
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"EnsureDropdownInitialized error: {ex.Message}");
+        }
+    }
+
+    
+    
     // 辅助方法
     private static bool IsMouseKeyCode(int keyCode) => keyCode switch
     {
@@ -410,4 +785,23 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
         7 => "WHEEL_DOWN",
         _ => "MOUSE_UNKNOWN"
     };
+}
+
+public class HotkeyOption
+{
+    public string DisplayName { get; set; }
+    public int KeyCode { get; set; }
+    public bool IsSeparator { get; set; }
+
+    public HotkeyOption(string displayName, int keyCode, bool isSeparator = false)
+    {
+        DisplayName = displayName;
+        KeyCode = keyCode;
+        IsSeparator = isSeparator;
+    }
+
+    public override string ToString()
+    {
+        return DisplayName;
+    }
 }

--- a/GalgameManager/Views/Control/FlexibleHotkeyInputBox.xaml.cs
+++ b/GalgameManager/Views/Control/FlexibleHotkeyInputBox.xaml.cs
@@ -4,6 +4,7 @@ using Windows.System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using CommunityToolkit.WinUI;
 
 namespace GalgameManager.Views.Control;
@@ -35,8 +36,15 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
         // 延迟初始化模式显示，确保控件完全加载
         Loaded += (sender, e) =>
         {
-            // 初始时默认为捕获模式
-            InputMode = InputMode.Capture;
+            // 如果没有通过 XAML 绑定设置 InputMode，尝试自动查找父级的 InputMode
+            if (InputMode == InputMode.Capture)
+            {
+                var parentInputMode = FindParentInputMode(this);
+                if (parentInputMode.HasValue)
+                {
+                    InputMode = parentInputMode.Value;
+                }
+            }
             UpdateDisplay();
         };
     }
@@ -773,6 +781,22 @@ public sealed partial class FlexibleHotkeyInputBox : INotifyPropertyChanged
         >= 1 and <= 7 => true, // 鼠标按键（包括滚轮上下6,7）
         _ => false
     };
+
+    private static InputMode? FindParentInputMode(DependencyObject child)
+    {
+        var parent = VisualTreeHelper.GetParent(child);
+        while (parent != null)
+        {
+            // 使用反射查找 InputMode 属性
+            var inputModeProp = parent.GetType().GetProperty("InputMode");
+            if (inputModeProp?.PropertyType == typeof(InputMode))
+            {
+                return (InputMode?)inputModeProp.GetValue(parent);
+            }
+            parent = VisualTreeHelper.GetParent(parent);
+        }
+        return null;
+    }
 
     private static string GetMouseDisplayName(int mouseCode) => mouseCode switch
     {

--- a/GalgameManager/Views/Control/SearchableTextBox.xaml
+++ b/GalgameManager/Views/Control/SearchableTextBox.xaml
@@ -1,0 +1,22 @@
+<UserControl
+    x:Class="GalgameManager.Views.Control.SearchableTextBox"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <AutoSuggestBox x:Uid="KeyMappingDialog_Placeholder_Description"
+                    Text="{x:Bind Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    AllowFocusOnInteraction="True"
+                    ItemsSource="{x:Bind Suggestions, Mode=OneWay}"
+                    IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"                    
+                    MaxSuggestionListHeight="200"
+                    AutoMaximizeSuggestionArea="True"
+                    TextChanged="AutoSuggestBox_OnTextChanged"
+                    QuerySubmitted="AutoSuggestBox_OnQuerySubmitted"
+                    GotFocus="MainAutoSuggestBox_GotFocus"
+                    LostFocus="MainAutoSuggestBox_LostFocus"
+                    KeyDown="MainAutoSuggestBox_KeyDown">
+    </AutoSuggestBox>
+</UserControl>

--- a/GalgameManager/Views/Control/SearchableTextBox.xaml.cs
+++ b/GalgameManager/Views/Control/SearchableTextBox.xaml.cs
@@ -1,0 +1,129 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.WinUI;
+using GalgameManager.Enums;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+
+namespace GalgameManager.Views.Control;
+
+public sealed partial class SearchableTextBox : UserControl
+{
+    public static readonly DependencyProperty TextProperty =
+        DependencyProperty.Register(nameof(Text), typeof(string), typeof(SearchableTextBox),
+            new PropertyMetadata(""));
+
+    public static readonly DependencyProperty SuggestionsProperty =
+        DependencyProperty.Register(nameof(Suggestions), typeof(ObservableCollection<string>), typeof(SearchableTextBox),
+            new PropertyMetadata(new ObservableCollection<string>()));
+
+    public string Text
+    {
+        get => (string)GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    public ObservableCollection<string> Suggestions
+    {
+        get => (ObservableCollection<string>)GetValue(SuggestionsProperty);
+        set => SetValue(SuggestionsProperty, value);
+    }
+
+    private string[] DefaultSuggestions => HotkeyResourceKeys.KnownKeys
+        .Select(keySuffix => $"{HotkeyResourceKeys.Prefix}{keySuffix}")
+        .Select(fullKey =>
+        {
+            try
+            {
+                var localizedValue = fullKey.GetLocalized();
+                return !string.IsNullOrEmpty(localizedValue) && localizedValue != fullKey ? localizedValue : null;
+            }
+            catch
+            {
+                return null;
+            }
+        })
+        .Where(value => value != null)
+        .ToArray()!;
+
+    
+    public SearchableTextBox()
+    {
+        this.InitializeComponent();
+
+        // 初始化建议列表（但不显示，等待用户点击或获得焦点）
+        Suggestions = new ObservableCollection<string>();
+    }
+
+    private void ShowAllSuggestions()
+    {
+        // 清空并重新添加所有建议
+        Suggestions.Clear();
+        foreach (var suggestion in DefaultSuggestions)
+        {
+            Suggestions.Add(suggestion);
+        }
+    }
+
+    private void AutoSuggestBox_OnTextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+    {
+        if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput) return;
+
+        // 如果用户开始输入，则进行过滤
+        if (!string.IsNullOrEmpty(Text))
+        {
+            var filtered = DefaultSuggestions
+                .Where(suggestion =>
+                    suggestion.Contains(Text, System.StringComparison.OrdinalIgnoreCase) ||
+                    Text.Contains(suggestion, System.StringComparison.OrdinalIgnoreCase))
+                .OrderBy(suggestion => suggestion.StartsWith(Text, System.StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+                .ThenBy(suggestion => suggestion)
+                .Take(10);
+
+            Suggestions.Clear();
+            foreach (var suggestion in filtered)
+            {
+                Suggestions.Add(suggestion);
+            }
+        }
+        else
+        {
+            // 如果输入为空，显示所有建议
+            ShowAllSuggestions();
+        }
+    }
+
+    private void AutoSuggestBox_OnQuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+    {
+        // 确认输入（无论用户选择建议项还是输入的内容）
+        ConfirmInputAndClearSuggestions();
+    }
+
+    private void MainAutoSuggestBox_GotFocus(object sender, RoutedEventArgs e)
+    {
+        // 当获得焦点时，显示所有建议
+        ShowAllSuggestions();
+    }
+
+    private void MainAutoSuggestBox_LostFocus(object sender, RoutedEventArgs e)
+    {
+        // 当失去焦点时（用户点击外部），确认输入并清除建议列表
+        ConfirmInputAndClearSuggestions();
+    }
+
+    private void MainAutoSuggestBox_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        // 处理 Enter 键
+        if (e.Key == Windows.System.VirtualKey.Enter)
+        {
+            e.Handled = true;
+            ConfirmInputAndClearSuggestions();
+        }
+    }
+
+    private void ConfirmInputAndClearSuggestions()
+    {
+        // 清除建议列表
+        Suggestions.Clear();
+    }
+}

--- a/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml
+++ b/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml
@@ -18,7 +18,7 @@
 
     <StackPanel Spacing="10">
         <!-- 输入模式切换 -->
-        <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Background="White" Padding="2" Visibility="{x:Bind HasMappings, Mode=OneWay}">
+        <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Background="White" Padding="2">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
@@ -34,13 +34,13 @@
                              x:Name="InputModeToggle"
                              x:Uid="KeyMappingDialog_InputModeToggle"
                              Toggled="InputModeToggle_Toggled"
-                             Margin="0" />
+                             Margin="0" 
+                             IsEnabled="{x:Bind HasMappings, Mode=OneWay}"/>
             </Grid>
         </Border>
 
         <!-- 表格容器 -->
-        <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Background="White"
-                Visibility="{x:Bind HasMappings, Mode=OneWay}">
+        <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Background="White">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -69,7 +69,7 @@
                 </Border>
 
                 <!-- 数据行容器 -->
-                <ScrollViewer Grid.Row="1" MaxHeight="400" MinHeight="200" VerticalScrollBarVisibility="Auto"
+                <ScrollViewer Grid.Row="1" MaxHeight="400" MinHeight="200" MinWidth="500" VerticalScrollBarVisibility="Auto"
                               HorizontalScrollBarVisibility="Disabled">
                     <ItemsControl ItemsSource="{x:Bind Mappings, Mode=OneWay}">
                         <ItemsControl.ItemTemplate>

--- a/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml
+++ b/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml
@@ -77,17 +77,16 @@
                                 <Border BorderBrush="#FFE0E0E0" BorderThickness="0,0,0,1" Padding="0">
                                     <Grid>
                                         <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" MinWidth="200" />
+                                            <ColumnDefinition Width="200"/>
                                             <ColumnDefinition Width="*" MinWidth="200" />
                                             <ColumnDefinition Width="50" />
                                             <ColumnDefinition Width="50" />
                                         </Grid.ColumnDefinitions>
 
                                         <!-- 说明列 -->
-                                        <TextBox Grid.Column="0" Text="{x:Bind Remark, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                 x:Uid="KeyMappingDialog_Placeholder_Description"
-                                                 VerticalAlignment="Center" MinWidth="150" BorderThickness="1"
-                                                 Margin="5"
+                                        <control:SearchableTextBox Grid.Column="0" Text="{x:Bind Remark, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 VerticalAlignment="Center" MinWidth="150" Margin="2,0,0,0"
+                                                 BorderThickness="1"
                                                  BorderBrush="{ThemeResource TextControlBorderBrush}"
                                                  Background="{ThemeResource TextControlBackground}"/>
 

--- a/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml
+++ b/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml
@@ -13,12 +13,12 @@
     DefaultButton="Primary">
 
     <ContentDialog.Resources>
-        <converter:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <x:Double x:Key="ContentDialogMinWidth">500</x:Double>
     </ContentDialog.Resources>
 
     <StackPanel Spacing="10">
         <!-- 输入模式切换 -->
-        <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Background="White" Padding="2">
+        <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Background="White" Padding="2" Visibility="{x:Bind HasMappings, Mode=OneWay}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
@@ -122,9 +122,6 @@
                 </ScrollViewer>
             </Grid>
         </Border>
-
-        <TextBlock x:Uid="GlobalKeyMappingDialog_Text_NoMappings" HorizontalAlignment="Center" Margin="0,10,0,0"
-                   Visibility="{x:Bind HasMappings, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=True}" />
 
         <Button Command="{x:Bind AddMappingCommand}" HorizontalAlignment="Stretch" Margin="0,10,0,0">
             <StackPanel Orientation="Horizontal" Spacing="8">

--- a/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml
+++ b/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml
@@ -17,6 +17,27 @@
     </ContentDialog.Resources>
 
     <StackPanel Spacing="10">
+        <!-- 输入模式切换 -->
+        <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Background="White" Padding="2">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Column="0"
+                           x:Uid="KeyMappingDialog_InputMode"
+                           VerticalAlignment="Center"
+                           Margin="10,0,0,0" />
+
+                <ToggleSwitch Grid.Column="1"
+                             x:Name="InputModeToggle"
+                             x:Uid="KeyMappingDialog_InputModeToggle"
+                             Toggled="InputModeToggle_Toggled"
+                             Margin="0" />
+            </Grid>
+        </Border>
+
         <!-- 表格容器 -->
         <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Background="White"
                 Visibility="{x:Bind HasMappings, Mode=OneWay}">

--- a/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml.cs
+++ b/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml.cs
@@ -6,8 +6,10 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using CommunityToolkit.Mvvm.Input;
 using GalgameManager.Models;
+using GalgameManager.Views.Control;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.WinUI;
 
@@ -97,6 +99,45 @@ public sealed partial class GlobalKeyMappingDialog : ContentDialog, INotifyPrope
         if (sender is Button button && button.Tag is KeyMapping mapping)
         {
             RemoveMapping(mapping);
+        }
+    }
+
+    private void InputModeToggle_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (sender is ToggleSwitch toggleSwitch)
+        {
+            var newMode = toggleSwitch.IsOn ? InputMode.Dropdown : InputMode.Capture;
+            UpdateAllInputBoxes(newMode);
+        }
+    }
+
+    private void UpdateAllInputBoxes(InputMode mode)
+    {
+        // 遍历所有FlexibleHotkeyInputBox并更新它们的模式
+        var inputBoxes = FindVisualChildren<FlexibleHotkeyInputBox>(this);
+        foreach (var inputBox in inputBoxes)
+        {
+            inputBox.InputMode = mode;
+        }
+    }
+
+    private static IEnumerable<T> FindVisualChildren<T>(DependencyObject? depObj) where T : DependencyObject
+    {
+        if (depObj != null)
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(depObj); i++)
+            {
+                DependencyObject? child = VisualTreeHelper.GetChild(depObj, i);
+                if (child != null && child is T)
+                {
+                    yield return (T)child;
+                }
+
+                foreach (T childOfChild in FindVisualChildren<T>(child))
+                {
+                    yield return childOfChild;
+                }
+            }
         }
     }
     

--- a/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml.cs
+++ b/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml.cs
@@ -125,7 +125,7 @@ public sealed partial class GlobalKeyMappingDialog : ContentDialog, INotifyPrope
     {
         if (depObj != null)
         {
-            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(depObj); i++)
+            for (var i = 0; i < VisualTreeHelper.GetChildrenCount(depObj); i++)
             {
                 DependencyObject? child = VisualTreeHelper.GetChild(depObj, i);
                 if (child != null && child is T)

--- a/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml.cs
+++ b/GalgameManager/Views/Dialog/GlobalKeyMappingDialog.xaml.cs
@@ -20,6 +20,23 @@ public sealed partial class GlobalKeyMappingDialog : ContentDialog, INotifyPrope
     private ObservableCollection<KeyMapping> _mappings = null!;
     private bool _hasMappings;
 
+    public static readonly DependencyProperty InputModeProperty =
+        DependencyProperty.Register(nameof(InputMode), typeof(InputMode), typeof(GlobalKeyMappingDialog), new PropertyMetadata(InputMode.Capture, OnInputModeChanged));
+
+    public InputMode InputMode
+    {
+        get => (InputMode)GetValue(InputModeProperty);
+        set => SetValue(InputModeProperty, value);
+    }
+
+    private static void OnInputModeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is GlobalKeyMappingDialog dialog)
+        {
+            dialog.UpdateAllInputBoxes((InputMode)e.NewValue);
+        }
+    }
+
     public ObservableCollection<KeyMapping> Mappings
     {
         get => _mappings;
@@ -69,7 +86,21 @@ public sealed partial class GlobalKeyMappingDialog : ContentDialog, INotifyPrope
         }
 
         UpdateHasMappings();
-        Mappings.CollectionChanged += (_, _) => UpdateHasMappings();
+        Mappings.CollectionChanged += (_, _) =>
+        {
+            UpdateHasMappings();
+
+            // 如果没有映射了，自动切换回捕获模式（关闭模式）
+            if (!HasMappings && InputMode == InputMode.Dropdown)
+            {
+                InputMode = InputMode.Capture;
+                // 同步 ToggleSwitch 状态
+                if (InputModeToggle != null)
+                {
+                    InputModeToggle.IsOn = false;
+                }
+            }
+        };
 
         // 清空按钮逻辑：直接清空并返回Secondary结果，让ViewModel处理保存
         SecondaryButtonClick += (_, _) => Mappings.Clear();
@@ -106,8 +137,7 @@ public sealed partial class GlobalKeyMappingDialog : ContentDialog, INotifyPrope
     {
         if (sender is ToggleSwitch toggleSwitch)
         {
-            var newMode = toggleSwitch.IsOn ? InputMode.Dropdown : InputMode.Capture;
-            UpdateAllInputBoxes(newMode);
+            InputMode = toggleSwitch.IsOn ? InputMode.Dropdown : InputMode.Capture;
         }
     }
 

--- a/GalgameManager/Views/Dialog/KeyMappingDialog.xaml
+++ b/GalgameManager/Views/Dialog/KeyMappingDialog.xaml
@@ -96,13 +96,9 @@
                                                   HorizontalAlignment="Left"
                                                   VerticalAlignment="Top"
                                                   Visibility="{x:Bind IsGlobal, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                            <TextBox Text="{x:Bind Remark, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                   PlaceholderText="{Binding KeyMappingDialog_Placeholder_Description, ElementName=dialog}"
+                                            <control:SearchableTextBox Text="{x:Bind Remark, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                    IsEnabled="{x:Bind IsGlobal, Converter={StaticResource InverseBooleanConverter}}"
-                                                   VerticalAlignment="Center" MinWidth="120" BorderThickness="1"
-                                                   Margin="5"
-                                                   BorderBrush="{ThemeResource TextControlBorderBrush}"
-                                                   Background="{ThemeResource TextControlBackground}"/>
+                                                   VerticalAlignment="Center" MinWidth="120" Margin="5"/>
                                         </Grid>
 
                                         <!-- 设置按键列 -->

--- a/GalgameManager/Views/Dialog/KeyMappingDialog.xaml
+++ b/GalgameManager/Views/Dialog/KeyMappingDialog.xaml
@@ -74,7 +74,7 @@
                 <!-- 数据行容器 -->
                 <ScrollViewer Grid.Row="1" MaxHeight="400" MinHeight="200" MinWidth="800" VerticalScrollBarVisibility="Auto"
                               HorizontalScrollBarVisibility="Disabled">
-                    <ItemsControl ItemsSource="{x:Bind ViewModel.KeyMappings, Mode=OneWay}">
+                    <ItemsControl ItemsSource="{x:Bind DialogKeyMappings, Mode=OneWay}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="models:KeyMapping">
                                 <Border BorderBrush="#FFE0E0E0" BorderThickness="0,0,0,1" Padding="0">
@@ -143,7 +143,7 @@
             </Grid>
         </Border>
 
-        <Button Command="{x:Bind ViewModel.AddKeyMappingCommand}" HorizontalAlignment="Stretch" Margin="0,10,0,0">
+        <Button Click="AddKeyMappingButton_Click" HorizontalAlignment="Stretch" Margin="0,10,0,0">
             <StackPanel Orientation="Horizontal" Spacing="8">
                 <SymbolIcon Symbol="Add"/>
                 <TextBlock Text="{Binding KeyMappingDialog_Button_AddMapping, ElementName=dialog}"/>

--- a/GalgameManager/Views/Dialog/KeyMappingDialog.xaml
+++ b/GalgameManager/Views/Dialog/KeyMappingDialog.xaml
@@ -35,7 +35,8 @@
                              x:Name="InputModeToggle"
                              x:Uid="KeyMappingDialog_InputModeToggle"
                              Toggled="InputModeToggle_Toggled"
-                             Margin="0" />
+                             Margin="0"
+                             IsEnabled="{x:Bind HasMappings, Mode=OneWay}"/>
             </Grid>
         </Border>
 
@@ -146,7 +147,7 @@
         <Button Click="AddKeyMappingButton_Click" HorizontalAlignment="Stretch" Margin="0,10,0,0">
             <StackPanel Orientation="Horizontal" Spacing="8">
                 <SymbolIcon Symbol="Add"/>
-                <TextBlock Text="{Binding KeyMappingDialog_Button_AddMapping, ElementName=dialog}"/>
+                <TextBlock x:Uid="KeyMappingDialog_Button_AddMapping"/>
             </StackPanel>
         </Button>
     </StackPanel>

--- a/GalgameManager/Views/Dialog/KeyMappingDialog.xaml
+++ b/GalgameManager/Views/Dialog/KeyMappingDialog.xaml
@@ -18,6 +18,27 @@
     </ContentDialog.Resources>
 
     <StackPanel Spacing="10">
+        <!-- 输入模式切换 -->
+        <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Background="White" Padding="2">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Column="0"
+                           x:Uid="KeyMappingDialog_InputMode"
+                           VerticalAlignment="Center"                         
+                           Margin="10,0,0,0" />
+
+                <ToggleSwitch Grid.Column="1"
+                             x:Name="InputModeToggle"
+                             x:Uid="KeyMappingDialog_InputModeToggle"
+                             Toggled="InputModeToggle_Toggled"
+                             Margin="0" />
+            </Grid>
+        </Border>
+
         <!-- 表格容器 -->
         <Border BorderBrush="#FFE0E0E0" BorderThickness="1" CornerRadius="4" Background="White">
             <Grid>

--- a/GalgameManager/Views/Dialog/KeyMappingDialog.xaml.cs
+++ b/GalgameManager/Views/Dialog/KeyMappingDialog.xaml.cs
@@ -1,8 +1,10 @@
 using GalgameManager.ViewModels;
 using Microsoft.UI.Xaml.Controls;
 using GalgameManager.Models;
+using GalgameManager.Views.Control;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
 using CommunityToolkit.WinUI;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -47,5 +49,44 @@ public sealed partial class KeyMappingDialog : ContentDialog
     {
         // 调用ViewModel的保存方法
         await ViewModel.SaveKeyMappingsAsync();
+    }
+
+    private void InputModeToggle_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (sender is ToggleSwitch toggleSwitch)
+        {
+            var newMode = toggleSwitch.IsOn ? InputMode.Dropdown : InputMode.Capture;
+            UpdateAllInputBoxes(newMode);
+        }
+    }
+
+    private void UpdateAllInputBoxes(InputMode mode)
+    {
+        // 遍历所有FlexibleHotkeyInputBox并更新它们的模式
+        var inputBoxes = FindVisualChildren<FlexibleHotkeyInputBox>(this);
+        foreach (var inputBox in inputBoxes)
+        {
+            inputBox.InputMode = mode;
+        }
+    }
+
+    private static IEnumerable<T> FindVisualChildren<T>(DependencyObject? depObj) where T : DependencyObject
+    {
+        if (depObj != null)
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(depObj); i++)
+            {
+                DependencyObject? child = VisualTreeHelper.GetChild(depObj, i);
+                if (child != null && child is T)
+                {
+                    yield return (T)child;
+                }
+
+                foreach (T childOfChild in FindVisualChildren<T>(child))
+                {
+                    yield return childOfChild;
+                }
+            }
+        }
     }
 }

--- a/GalgameManager/Views/Dialog/KeyMappingDialog.xaml.cs
+++ b/GalgameManager/Views/Dialog/KeyMappingDialog.xaml.cs
@@ -2,17 +2,19 @@ using GalgameManager.ViewModels;
 using Microsoft.UI.Xaml.Controls;
 using GalgameManager.Models;
 using GalgameManager.Views.Control;
-using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using CommunityToolkit.WinUI;
 using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.ObjectModel;
 
 namespace GalgameManager.Views.Dialog;
 
 public sealed partial class KeyMappingDialog : ContentDialog
 {
     public GalgameSettingViewModel ViewModel { get; }
+    public ObservableCollection<KeyMapping> DialogKeyMappings { get; private set; } = null!;
+    private readonly ObservableCollection<KeyMapping> _originalKeyMappings;
 
     public KeyMappingDialog(GalgameSettingViewModel viewModel)
     {
@@ -25,15 +27,36 @@ public sealed partial class KeyMappingDialog : ContentDialog
         PrimaryButtonText = "KeyMappingDialog_Button_Save".GetLocalized();
         CloseButtonText = "KeyMappingDialog_Button_Close".GetLocalized();
 
+        // 创建原始数据的深拷贝，完全不修改 ViewModel 的数据
+        _originalKeyMappings = new ObservableCollection<KeyMapping>(ViewModel.KeyMappings);
+        DialogKeyMappings = CreateDeepCopy(_originalKeyMappings);
+
         // 添加PrimaryButtonClick事件处理
         PrimaryButtonClick += OnSaveButtonClick;
+    }
+
+    private ObservableCollection<KeyMapping> CreateDeepCopy(ObservableCollection<KeyMapping> source)
+    {
+        var copy = new ObservableCollection<KeyMapping>();
+        foreach (var mapping in source)
+        {
+            copy.Add(new KeyMapping
+            {
+                Remark = mapping.Remark,
+                From = mapping.From?.ToList() ?? [],
+                To = mapping.To?.ToList() ?? [],
+                IsEnabled = mapping.IsEnabled,
+                IsGlobal = mapping.IsGlobal
+            });
+        }
+        return copy;
     }
 
     private void RemoveKeyMapping(KeyMapping? mapping)
     {
         if (mapping != null) // 允许删除所有快捷键，包括全局快捷键
         {
-            ViewModel.KeyMappings.Remove(mapping);
+            DialogKeyMappings.Remove(mapping);
         }
     }
 
@@ -45,10 +68,20 @@ public sealed partial class KeyMappingDialog : ContentDialog
         }
     }
 
-    private async void OnSaveButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    private void OnSaveButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
-        // 调用ViewModel的保存方法
-        await ViewModel.SaveKeyMappingsAsync();
+        // 只有在用户点击保存时，才将对话框中的数据应用到 ViewModel
+        ViewModel.KeyMappings = new ObservableCollection<KeyMapping>(DialogKeyMappings);
+    }
+
+    private void AddKeyMapping()
+    {
+        DialogKeyMappings.Add(new KeyMapping { IsGlobal = false });
+    }
+
+    private void AddKeyMappingButton_Click(object sender, RoutedEventArgs e)
+    {
+        AddKeyMapping();
     }
 
     private void InputModeToggle_Toggled(object sender, RoutedEventArgs e)
@@ -74,7 +107,7 @@ public sealed partial class KeyMappingDialog : ContentDialog
     {
         if (depObj != null)
         {
-            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(depObj); i++)
+            for (var i = 0; i < VisualTreeHelper.GetChildrenCount(depObj); i++)
             {
                 DependencyObject? child = VisualTreeHelper.GetChild(depObj, i);
                 if (child != null && child is T)

--- a/GalgameManager/Views/Dialog/KeyMappingDialog.xaml.cs
+++ b/GalgameManager/Views/Dialog/KeyMappingDialog.xaml.cs
@@ -5,7 +5,6 @@ using GalgameManager.Views.Control;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using CommunityToolkit.WinUI;
-using CommunityToolkit.Mvvm.ComponentModel;
 using System.Collections.ObjectModel;
 
 namespace GalgameManager.Views.Dialog;
@@ -15,6 +14,32 @@ public sealed partial class KeyMappingDialog : ContentDialog
     public GalgameSettingViewModel ViewModel { get; }
     public ObservableCollection<KeyMapping> DialogKeyMappings { get; private set; } = null!;
     private readonly ObservableCollection<KeyMapping> _originalKeyMappings;
+
+    public static readonly DependencyProperty HasMappingsProperty =
+        DependencyProperty.Register(nameof(HasMappings), typeof(bool), typeof(KeyMappingDialog), new PropertyMetadata(false));
+
+    public bool HasMappings
+    {
+        get => (bool)GetValue(HasMappingsProperty);
+        private set => SetValue(HasMappingsProperty, value);
+    }
+
+    public static readonly DependencyProperty InputModeProperty =
+        DependencyProperty.Register(nameof(InputMode), typeof(InputMode), typeof(KeyMappingDialog), new PropertyMetadata(InputMode.Capture, OnInputModeChanged));
+
+    public InputMode InputMode
+    {
+        get => (InputMode)GetValue(InputModeProperty);
+        set => SetValue(InputModeProperty, value);
+    }
+
+    private static void OnInputModeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is KeyMappingDialog dialog)
+        {
+            dialog.UpdateAllInputBoxes((InputMode)e.NewValue);
+        }
+    }
 
     public KeyMappingDialog(GalgameSettingViewModel viewModel)
     {
@@ -30,6 +55,9 @@ public sealed partial class KeyMappingDialog : ContentDialog
         // 创建原始数据的深拷贝，完全不修改 ViewModel 的数据
         _originalKeyMappings = new ObservableCollection<KeyMapping>(ViewModel.KeyMappings);
         DialogKeyMappings = CreateDeepCopy(_originalKeyMappings);
+
+        // 初始化 HasMappings 状态
+        UpdateHasMappings();
 
         // 添加PrimaryButtonClick事件处理
         PrimaryButtonClick += OnSaveButtonClick;
@@ -57,6 +85,7 @@ public sealed partial class KeyMappingDialog : ContentDialog
         if (mapping != null) // 允许删除所有快捷键，包括全局快捷键
         {
             DialogKeyMappings.Remove(mapping);
+            UpdateHasMappings();
         }
     }
 
@@ -77,6 +106,7 @@ public sealed partial class KeyMappingDialog : ContentDialog
     private void AddKeyMapping()
     {
         DialogKeyMappings.Add(new KeyMapping { IsGlobal = false });
+        UpdateHasMappings();
     }
 
     private void AddKeyMappingButton_Click(object sender, RoutedEventArgs e)
@@ -84,12 +114,27 @@ public sealed partial class KeyMappingDialog : ContentDialog
         AddKeyMapping();
     }
 
+    private void UpdateHasMappings()
+    {
+        HasMappings = DialogKeyMappings.Count > 0;
+
+        // 如果没有映射了，自动切换回捕获模式（关闭模式）
+        if (!HasMappings && InputMode == InputMode.Dropdown)
+        {
+            InputMode = InputMode.Capture;
+            // 同步 ToggleSwitch 状态
+            if (InputModeToggle != null)
+            {
+                InputModeToggle.IsOn = false;
+            }
+        }
+    }
+
     private void InputModeToggle_Toggled(object sender, RoutedEventArgs e)
     {
         if (sender is ToggleSwitch toggleSwitch)
         {
-            var newMode = toggleSwitch.IsOn ? InputMode.Dropdown : InputMode.Capture;
-            UpdateAllInputBoxes(newMode);
+            InputMode = toggleSwitch.IsOn ? InputMode.Dropdown : InputMode.Capture;
         }
     }
 


### PR DESCRIPTION
1. 可以快速的输入常用的快捷键了
2. 快捷键输入模式可以通过列表选择，方便映射硬件上没或者不方便输入的按键
3. 单独游戏中的快捷键只有点击保存后才会保存

![switch](https://github.com/user-attachments/assets/2351c0eb-f7b3-4f71-8ebf-6f01c8f1d043)
