### PR TITLE
feat: allow sync game save file

### DIFF
--- a/GalgameManager/Helpers/FolderOperations.cs
+++ b/GalgameManager/Helpers/FolderOperations.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
@@ -50,28 +50,47 @@ public static class FolderOperations
     /// <summary>
     /// 将文件夹转换为符号链接
     /// </summary>
-    /// <param name="sourceFolderPath">原文件夹地址</param>
-    /// <param name="targetFolderPath">映射目标地址</param>
+    /// <param name="sourcePath">原文件/文件夹地址</param>
+    /// <param name="targetPath">映射目标地址</param>
     /// <exception cref="ArgumentException">原地址/目标地址为空或null</exception>
     /// <exception cref="DirectoryNotFoundException">原地址不存在</exception>
-    public static void ConvertFolderToSymbolicLink(string sourceFolderPath, string targetFolderPath)
+    public static void ConvertFolderOrFileToSymbolicLink(string sourcePath, string targetPath)
     {
-        if (string.IsNullOrEmpty(sourceFolderPath) || string.IsNullOrEmpty(targetFolderPath))
+        var isSrcFolder = File.GetAttributes(sourcePath).HasFlag(FileAttributes.Directory);
+        
+        if (string.IsNullOrEmpty(sourcePath) || string.IsNullOrEmpty(targetPath))
         {
             throw new ArgumentException("Source and target folder paths cannot be null or empty.");
         }
-        if (!Directory.Exists(sourceFolderPath))
+        if (isSrcFolder && !Directory.Exists(sourcePath))
         {
-            throw new DirectoryNotFoundException($"Source folder not found: {sourceFolderPath}");
+            throw new DirectoryNotFoundException($"Source folder not found: {sourcePath}");
         }
-        // 创建目标文件夹（如果不存在）
-        Directory.CreateDirectory(targetFolderPath);
-        // 将源文件夹内容移动到目标文件夹
-        Copy(sourceFolderPath, targetFolderPath);
-        // 删除原始文件夹
-        Directory.Delete(sourceFolderPath, true);
-        // 创建符号链接
-        CreateSymbolicLink(sourceFolderPath, targetFolderPath);
+        if (!isSrcFolder && !File.Exists(sourcePath))
+        {
+            throw new FileNotFoundException($"Source file not found: {sourcePath}");
+        }
+        // 1. 创建目标文件夹（如果不存在）        
+        // 2. 将源文件夹内容移动到目标文件夹
+        // 3. 删除原始文件夹
+        if (isSrcFolder)
+        {
+            Directory.CreateDirectory(targetPath);
+            Copy(sourcePath, targetPath);
+            Directory.Delete(sourcePath, true);
+        } 
+        else
+        {
+            var targetFolder = Path.GetDirectoryName(targetPath);
+            if (targetFolder is null)
+            {
+                throw new ArgumentException($"Invalid path: {targetPath}");
+            }
+            Directory.CreateDirectory(targetFolder);
+            File.Move(sourcePath, targetPath, true);
+        }
+        // 4. 创建符号链接
+        CreateSymbolicLink(sourcePath, targetPath);
     }
 
     /// <summary>
@@ -81,17 +100,27 @@ public static class FolderOperations
     /// <param name="targetFolderPath">引用地址</param>
     public static void CreateSymbolicLink(string sourceFolderPath, string targetFolderPath)
     {
+        var isTargetFolder = File.GetAttributes(targetFolderPath).HasFlag(FileAttributes.Directory);
+
+        var linkPath = sourceFolderPath;
+        var realPath = targetFolderPath;
+
+        var args = $"/c mklink {(isTargetFolder ? "/D" : "")} \"{linkPath}\" \"{realPath}\"";
+
         ProcessStartInfo processInfo = new()
         {
             Verb = "runas",
             FileName = "cmd.exe",
-            Arguments = $"/c mklink /D \"{sourceFolderPath}\" \"{targetFolderPath}\"",
+            Arguments = args,
             UseShellExecute = true,
         };
         Process? process = Process.Start(processInfo);
         if (process is null) throw new Exception("Failed to start cmd.exe");
         process.WaitForExit();
-        if (Directory.Exists(sourceFolderPath) == false)
+
+        if (isTargetFolder && Directory.Exists(sourceFolderPath) == false)
+            throw new Exception("Failed to create symbolic link.");
+        if (!isTargetFolder && Path.Exists(sourceFolderPath) == false)
             throw new Exception("Failed to create symbolic link.");
     }
 

--- a/GalgameManager/Models/Galgame.cs
+++ b/GalgameManager/Models/Galgame.cs
@@ -233,6 +233,23 @@ public partial class Galgame : ObservableObject, IDisplayableGameObject
         List<string> result = Directory.GetDirectories(LocalPath).ToList();
         return result;
     }
+    
+    /// <summary>
+    /// 获取游戏文件夹根目录下的所有文件
+    /// </summary>
+    /// <returns>子文件夹地址</returns>
+    public List<string> GetRootFiles()
+    {
+        if (LocalPath is null) return [];
+        HashSet<string> commonExtensions = new (StringComparer.OrdinalIgnoreCase)
+        {
+            ".exe", ".xp3", ".lnk", ".txt", ".ico", ".sig", ".dll",
+        };
+        List<string> result = Directory.GetFiles(LocalPath)
+            .Where(el => !commonExtensions.Contains(System.IO.Path.GetExtension(el)))
+            .ToList();
+        return result;
+    }
 
     /// <summary>
     /// 尝试获取游戏的id，以int形式返回 <br/>

--- a/GalgameManager/Services/GalgameCollectionService/GalgameCollectionService.cs
+++ b/GalgameManager/Services/GalgameCollectionService/GalgameCollectionService.cs
@@ -18,6 +18,7 @@ using GalgameManager.Views.Dialog;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using LiteDB;
+using FileAttributes = System.IO.FileAttributes;
 
 namespace GalgameManager.Services;
 
@@ -579,9 +580,34 @@ public partial class GalgameCollectionService : IGalgameCollectionService
     /// <returns>存档文件夹地址，若用户取消返回null</returns>
     private async Task<string?> GetGalgameSaveAsync(Galgame galgame)
     {
-        List<string> subFolders = galgame.GetSubFolders();
-        FolderPickerDialog dialog = new(App.MainWindow!.Content.XamlRoot, "GalgameCollectionService_SelectSavePosition".GetLocalized(), subFolders);
-        return await dialog.ShowAndAwaitResultAsync();
+        ContentDialog folderOrFileSelector = new()
+        {
+            XamlRoot = App.MainWindow!.Content.XamlRoot,
+            Title = "Yes".GetLocalized(),
+            Content = "GalgameCollectionService_SelectSaveType".GetLocalized(),
+            PrimaryButtonText = "GalgameCollectionService_SelectSaveType_File".GetLocalized(),
+            SecondaryButtonText = "GalgameCollectionService_SelectSaveType_Folder".GetLocalized(),
+            CloseButtonText = "Cancel".GetLocalized(),
+        };
+        var typeResult = await folderOrFileSelector.ShowAsync();
+
+        switch (typeResult)
+        {
+            case ContentDialogResult.Primary:  // File
+            {
+                List<string> rootFiles = galgame.GetRootFiles();
+                FolderOrFilePickerDialog dialog = new(App.MainWindow!.Content.XamlRoot, "GalgameCollectionService_SelectSavePosition_File".GetLocalized(), rootFiles, false);
+                return await dialog.ShowAndAwaitResultAsync();
+            }
+            case ContentDialogResult.Secondary: // Folder
+            {
+                List<string> subFolders = galgame.GetSubFolders();
+                FolderOrFilePickerDialog dialog = new(App.MainWindow!.Content.XamlRoot, "GalgameCollectionService_SelectSavePosition_Folder".GetLocalized(), subFolders, true);
+                return await dialog.ShowAndAwaitResultAsync();
+            }
+        }
+
+        return null;
     }
     
     /// <summary>
@@ -653,6 +679,8 @@ public partial class GalgameCollectionService : IGalgameCollectionService
             if (localSavePath == null) return;
             if (Utils.ArePathsEqual(remoteRoot, localSavePath))
                 throw new PvnException("GalgameCollectionService_SavePathIsCloudRoot".GetLocalized());
+            if (galgame.LocalPath != null && Utils.IsPathContained(localSavePath, galgame.LocalPath))
+                throw new PvnException("GalgameCollectionService_SavePathIsGameRoot".GetLocalized());
             if (FolderOperations.IsSymbolicLink(localSavePath))
             {
                 _infoService.Info(InfoBarSeverity.Warning, msg:"GalgameCollectionService_SavePathIsSymbolicLink".GetLocalized());
@@ -660,7 +688,9 @@ public partial class GalgameCollectionService : IGalgameCollectionService
                 await SaveGalgameAsync(galgame);
                 return;
             }
-            
+
+            var isSaveFolder  = (File.GetAttributes(localSavePath) & FileAttributes.Directory) == FileAttributes.Directory;
+
             var tmp = localSavePath[..localSavePath.LastIndexOf('\\')];
             var target = tmp[tmp.LastIndexOf('\\')..] + localSavePath[localSavePath.LastIndexOf('\\')..];
             remoteRoot += target;
@@ -685,7 +715,7 @@ public partial class GalgameCollectionService : IGalgameCollectionService
                     if (choose == 1)
                     {
                         new DirectoryInfo(remoteRoot).Delete(true); //删除云端文件夹
-                        FolderOperations.ConvertFolderToSymbolicLink(localSavePath, remoteRoot);
+                        FolderOperations.ConvertFolderOrFileToSymbolicLink(localSavePath, remoteRoot);
                     }
                     else if (choose == 2)
                     {
@@ -694,7 +724,7 @@ public partial class GalgameCollectionService : IGalgameCollectionService
                     }
                 }
                 else
-                    FolderOperations.ConvertFolderToSymbolicLink(localSavePath, remoteRoot);
+                    FolderOperations.ConvertFolderOrFileToSymbolicLink(localSavePath, remoteRoot);
                 galgame.SavePath = localSavePath;
             }
             catch (Exception e) //创建符号链接失败，把存档复制回去
@@ -871,33 +901,51 @@ public partial class GalgameCollectionService : IGalgameCollectionService
     }
 }
 
-public class FolderPickerDialog : ContentDialog
+public class FolderOrFilePickerDialog : ContentDialog
 {
-    private string? _selectedFolder;
+    private string? _selectedItem;
     private readonly TaskCompletionSource<string?> _folderSelectedTcs = new TaskCompletionSource<string?>();
-    public FolderPickerDialog(XamlRoot xamlRoot, string title, List<string> files)
+    public FolderOrFilePickerDialog(XamlRoot xamlRoot, string title, List<string> files, bool isFolder = true)
     {
         XamlRoot = xamlRoot;
         Title = title;
         Content = CreateContent(files);
         PrimaryButtonText = "Yes".GetLocalized();
-        SecondaryButtonText = "GalgameCollectionService_FolderPickerDialog_ChoseAnotherFolder".GetLocalized();
+        SecondaryButtonText = "GalgameCollectionService_FolderOrFilePickerDialog_Other".GetLocalized();
         CloseButtonText = "Cancel".GetLocalized();
         IsPrimaryButtonEnabled = false;
-        PrimaryButtonClick += (_, _) => { _folderSelectedTcs.TrySetResult(_selectedFolder); };
+        
+        PrimaryButtonClick += (_, _) => { _folderSelectedTcs.TrySetResult(_selectedItem); };
         SecondaryButtonClick += async (_, _) =>
         {
-            FolderPicker folderPicker = new();
-            folderPicker.FileTypeFilter.Add("*");
-            WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, App.MainWindow!.GetWindowHandle());
-            StorageFolder? folder = await folderPicker.PickSingleFolderAsync();
-            if (folder != null)
+            if (isFolder)
             {
-                _selectedFolder = folder.Path;
-                _folderSelectedTcs.TrySetResult(folder.Path);
+                FolderPicker folderPicker = new();
+                folderPicker.FileTypeFilter.Add("*");
+                WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, App.MainWindow!.GetWindowHandle());
+                StorageFolder? folder = await folderPicker.PickSingleFolderAsync();
+                if (folder != null)
+                {
+                    _selectedItem = folder.Path;
+                    _folderSelectedTcs.TrySetResult(folder.Path);
+                }
+                else
+                    _folderSelectedTcs.TrySetResult(null);
             }
             else
-                _folderSelectedTcs.TrySetResult(null);
+            {
+                FileOpenPicker filesPicker = new();
+                filesPicker.FileTypeFilter.Add("*");
+                WinRT.Interop.InitializeWithWindow.Initialize(filesPicker, App.MainWindow!.GetWindowHandle());
+                StorageFile? folder = await filesPicker.PickSingleFileAsync();
+                if (folder != null)
+                {
+                    _selectedItem = folder.Path;
+                    _folderSelectedTcs.TrySetResult(folder.Path);
+                }
+                else
+                    _folderSelectedTcs.TrySetResult(null);
+            }
         };
         CloseButtonClick += (_, _) => { _folderSelectedTcs.TrySetResult(null); };
     }
@@ -919,7 +967,7 @@ public class FolderPickerDialog : ContentDialog
     private void RadioButton_Checked(object sender, RoutedEventArgs e)
     {
         RadioButton radioButton = (RadioButton)sender;
-        _selectedFolder = radioButton.Content.ToString()!;
+        _selectedItem = radioButton.Content.ToString()!;
         IsPrimaryButtonEnabled = true;
     }
     public async Task<string?> ShowAndAwaitResultAsync()

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -341,7 +341,7 @@ If you would like to use cloud saves, dropping local saves, pls chose Cloud.</va
   <data name="GalgamePage_Description.Text" xml:space="preserve">
     <value>Description</value>
   </data>
-  <data name="GalgameCollectionService_SelectSavePosition" xml:space="preserve">
+  <data name="GalgameCollectionService_SelectSavePosition_Folder" xml:space="preserve">
     <value>Select game save folder</value>
   </data>
   <data name="GalgameCollectionService_NotExeFounded" xml:space="preserve">
@@ -3280,11 +3280,11 @@ If play time can record correctly, just cancel this popup.
   <data name="GlobalKeyMappingDialog_Button_Cancel" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="KeyMapping_Info_KeyMappingSaved" xml:space="preserve">
-    <value>Key mapping saved</value>
-  </data>
   <data name="GlobalKeyMappingDialog_Text_NoMappings.Text" xml:space="preserve">
     <value>No key mappings available</value>
+  </data>
+  <data name="KeyMapping_Info_KeyMappingSaved" xml:space="preserve">
+    <value>Key mapping saved</value>
   </data>
   <data name="SettingsPage_Game_GlobalKeyMapping.Title" xml:space="preserve">
     <value>Global Key Mapping</value>
@@ -3309,9 +3309,6 @@ If play time can record correctly, just cancel this popup.
   </data>
   <data name="KeyMapping_Info_MouseCapturing" xml:space="preserve">
     <value>Mouse button capture is enabled, click mouse button in input box</value>
-  </data>
-  <data name="KeyMapping_Info_KeyMappingSaved" xml:space="preserve">
-    <value>Key mapping saved</value>
   </data>
   <data name="KeyMapping_Info_GlobalKeyMappingSaved" xml:space="preserve">
     <value>Global key mapping saved</value>
@@ -3454,7 +3451,7 @@ If play time can record correctly, just cancel this popup.
   <data name="GalgameSettingPage_SavePositionSetFailed" xml:space="preserve">
     <value>Failed to set save position</value>
   </data>
-	<data name="GalgameSettingPage_ReDetect.Text" xml:space="preserve">
+  <data name="GalgameSettingPage_ReDetect.Text" xml:space="preserve">
     <value>ReDetect Path</value>
   </data>
   <data name="GalgameSettingPage_ReDetectSuccess" xml:space="preserve">
@@ -3538,5 +3535,7 @@ If play time can record correctly, just cancel this popup.
   <data name="GameCharacterPanel_DeleteCharacter_Success" xml:space="preserve">
     <value>Character deleted successfully</value>
   </data>
-
+  <data name="GalgameCollectionService_SelectSavePosition_File" xml:space="preserve">
+    <value>Select game save file</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -341,7 +341,7 @@
   <data name="GalgamePage_Description.Text" xml:space="preserve">
     <value>概要</value>
   </data>
-  <data name="GalgameCollectionService_SelectSavePosition" xml:space="preserve">
+  <data name="GalgameCollectionService_SelectSavePosition_Folder" xml:space="preserve">
     <value>セーブフォルダを選択</value>
   </data>
   <data name="GalgameCollectionService_NotExeFounded" xml:space="preserve">
@@ -3245,11 +3245,11 @@
   <data name="GlobalKeyMappingDialog_Button_Cancel" xml:space="preserve">
     <value>キャンセル</value>
   </data>
-  <data name="KeyMapping_Info_KeyMappingSaved" xml:space="preserve">
-    <value>キーマッピングが保存されました</value>
-  </data>
   <data name="GlobalKeyMappingDialog_Text_NoMappings.Text" xml:space="preserve">
     <value>キーマッピングがありません</value>
+  </data>
+  <data name="KeyMapping_Info_KeyMappingSaved" xml:space="preserve">
+    <value>キーマッピングが保存されました</value>
   </data>
   <data name="SettingsPage_Game_GlobalKeyMapping.Title" xml:space="preserve">
     <value>グローバルキーマッピング</value>
@@ -3274,9 +3274,6 @@
   </data>
   <data name="KeyMapping_Info_MouseCapturing" xml:space="preserve">
     <value>マウスボタンキャプチャが有効、入力ボックス内でマウスボタンをクリックしてください</value>
-  </data>
-  <data name="KeyMapping_Info_KeyMappingSaved" xml:space="preserve">
-    <value>キーマッピングが保存されました</value>
   </data>
   <data name="KeyMapping_Info_GlobalKeyMappingSaved" xml:space="preserve">
     <value>グローバルキーマッピングが保存されました</value>
@@ -3473,5 +3470,4 @@
   <data name="GameCharacterPanel_DeleteCharacter_Success" xml:space="preserve">
     <value>キャラクターを削除しました</value>
   </data>
-
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -353,7 +353,7 @@
   <data name="GalgamePage_Description.Text" xml:space="preserve">
     <value>简介</value>
   </data>
-  <data name="GalgameCollectionService_SelectSavePosition" xml:space="preserve">
+  <data name="GalgameCollectionService_SelectSavePosition_Folder" xml:space="preserve">
     <value>选择存档文件夹</value>
   </data>
   <data name="GalgameCollectionService_NotExeFounded" xml:space="preserve">
@@ -3973,9 +3973,6 @@
   <data name="KeyMapping_Info_MouseCapturing" xml:space="preserve">
     <value>鼠标按键捕获已启用，请在输入框内点击鼠标按键</value>
   </data>
-  <data name="KeyMapping_Info_KeyMappingSaved" xml:space="preserve">
-    <value>按键映射已保存</value>
-  </data>
   <data name="KeyMapping_Info_GlobalKeyMappingSaved" xml:space="preserve">
     <value>全局按键映射已保存</value>
   </data>
@@ -4201,5 +4198,22 @@
   <data name="GameCharacterPanel_DeleteCharacter_Success" xml:space="preserve">
     <value>成功删除角色</value>
   </data>
-
+  <data name="GalgameCollectionService_SelectSaveType" xml:space="preserve">
+    <value>请选择存档类型</value>
+  </data>
+  <data name="GalgameCollectionService_SelectSaveType_Folder" xml:space="preserve">
+    <value>文件夹</value>
+  </data>
+  <data name="GalgameCollectionService_SelectSaveType_File" xml:space="preserve">
+    <value>文件</value>
+  </data>
+  <data name="GalgameCollectionService_SelectSavePosition_File" xml:space="preserve">
+    <value>选择存档文件</value>
+  </data>
+  <data name="GalgameCollectionService_FolderOrFilePickerDialog_Other" xml:space="preserve">
+    <value>其他</value>
+  </data>
+  <data name="GalgameCollectionService_SavePathIsGameRoot" xml:space="preserve">
+    <value>你选错目录啦，这里应该选择这个游戏的存档文件夹，而不是游戏文件的根目录~</value>
+  </data>
 </root>


### PR DESCRIPTION
feat: 允许选择**单个**文件作为存档同步
fix: 禁止使用某些目录作为存档同步目标，aka 游戏目录是该目录的子目录。


未来可以添加的功能（本 pr 不涉及，等一个有缘人继续写）
- 允许选择多个文件/文件夹进行同步

<img width="575" height="366" alt="image" src="https://github.com/user-attachments/assets/19839c67-5877-4d2d-af26-c83aa21eef55" />
<img width="590" height="553" alt="image" src="https://github.com/user-attachments/assets/950e7acd-f303-4d46-a775-4cb9c330fa0b" />
<img width="554" height="423" alt="image" src="https://github.com/user-attachments/assets/19a71bec-1d01-4d06-a739-59ff64b0f6c3" />

