### PR TITLE
feat(plugin): load dev plugin from memory

### DIFF
--- a/GalgameManager.WinApp.Base/Contracts/IPlugin.cs
+++ b/GalgameManager.WinApp.Base/Contracts/IPlugin.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using GalgameManager.WinApp.Base.Models;
 
 namespace GalgameManager.WinApp.Base.Contracts;
@@ -16,4 +18,18 @@ public interface IPlugin
     /// </summary>
     /// <returns></returns>
     public Task InitializeAsync(IPotatoVnApi hostApi);
+
+    /// <summary>
+    /// 插件被卸载的时候会被调用，用于清理一些插件相关的外部配置和数据
+    /// </summary>
+    /// <remarks>
+    /// 对于开发阶段的插件可以在这个接口中实现热重载相关逻辑方便开发。
+    /// 插件默认最多用时 5s，可以通过 extendWaitHandler 延长，但是无法超过 60s
+    /// </remarks>
+    /// <returns></returns>
+    public Task OnUninstallAsync(bool deleteData, Action<TimeSpan> extendWaitHandler, CancellationToken cts)
+    {
+        if (cts.IsCancellationRequested) return Task.FromCanceled(cts);
+        return Task.CompletedTask;
+    }
 }

--- a/GalgameManager/Contracts/Services/IPluginService.cs
+++ b/GalgameManager/Contracts/Services/IPluginService.cs
@@ -6,24 +6,6 @@ namespace GalgameManager.Contracts.Services;
 public interface IPluginService
 {
     /// <summary>
-    /// 是否有正在等待取消加载/删除的插件
-    /// </summary>
-    public bool PluginOffloadInProgress { get; }
-    
-    /// <summary>
-    /// 立即设置插件的关联数据
-    /// </summary>
-    /// <param name="plugin"></param>
-    /// <param name="data"></param>
-    public void PluginSetData(PluginX plugin, string? data); 
-    
-    /// <summary>
-    /// 立即删除插件的关联数据
-    /// </summary>
-    /// <param name="plugin"></param>
-    public void PluginDeleteData(PluginX plugin); 
-    
-    /// <summary>
     /// 新增插件，注意捕获异常
     /// </summary>
     /// <param name="path"></param>
@@ -42,9 +24,9 @@ public interface IPluginService
     public Task DeletePluginAsync(PluginX plugin, bool deleteData);
     
     public Task<ObservableCollection<PluginX>> GetAllPluginsAsync();
-    
+
     public Task InitAsync();
-    
+
     /// <summary>
     /// 加载某个插件，如果已经加载则不操作，注意捕获异常
     /// </summary>
@@ -52,11 +34,29 @@ public interface IPluginService
     /// <param name="load">是否要加载插件，若设置为false则只把插件加到插件列表里而不加载（初始化插件表时用）</param>
     /// <returns></returns>
     public Task LoadPluginAsync(PluginX plugin, bool load);
+    
+    /// <summary>
+    /// 立即删除插件的关联数据
+    /// </summary>
+    /// <param name="plugin"></param>
+    public void PluginDeleteData(PluginX plugin); 
 
     /// <summary>
     /// 插件存放目录
     /// </summary>
     public DirectoryInfo PluginDir { get; }
+    
+    /// <summary>
+    /// 是否有正在等待取消加载/删除的插件
+    /// </summary>
+    public bool PluginOffloadInProgress { get; }
+    
+    /// <summary>
+    /// 立即设置插件的关联数据
+    /// </summary>
+    /// <param name="plugin"></param>
+    /// <param name="data"></param>
+    public void PluginSetData(PluginX plugin, string? data); 
     
     /// <summary>
     /// 当调用插件功能抛出异常时可以调用此方法提醒用户（内部会调用infoService发送一个Event）

--- a/GalgameManager/Contracts/Services/IPluginService.cs
+++ b/GalgameManager/Contracts/Services/IPluginService.cs
@@ -11,12 +11,26 @@ public interface IPluginService
     public bool PluginOffloadInProgress { get; }
     
     /// <summary>
+    /// 立即设置插件的关联数据
+    /// </summary>
+    /// <param name="plugin"></param>
+    /// <param name="data"></param>
+    public void PluginSetData(PluginX plugin, string? data); 
+    
+    /// <summary>
+    /// 立即删除插件的关联数据
+    /// </summary>
+    /// <param name="plugin"></param>
+    public void PluginDeleteData(PluginX plugin); 
+    
+    /// <summary>
     /// 新增插件，注意捕获异常
     /// </summary>
     /// <param name="path"></param>
+    /// <param name="isDev"> 是否以 Dev 模式加载插件 </param>
     /// <exception cref="PvnException">已知错误</exception>
     /// <returns></returns>
-    public Task AddPluginAsync(string path);
+    public Task AddPluginAsync(string path, bool isDev);
 
     /// <summary>
     /// 标记一个插件要卸载，下次启动时会卸载插件。 <br/>

--- a/GalgameManager/Models/BgTasks/InstallStorePluginTask.cs
+++ b/GalgameManager/Models/BgTasks/InstallStorePluginTask.cs
@@ -62,7 +62,8 @@ public class InstallStorePluginTask : BgTaskBase
             await ExtractPluginAsync(zipPath, PluginFolderPath);
 
             IPluginService pluginService = App.GetService<IPluginService>();
-            await pluginService.AddPluginAsync(PluginFolderPath);
+            // 从商店安装的 plugin 永远非 dev 模式。
+            await pluginService.AddPluginAsync(PluginFolderPath, false);
 
             ChangeProgress(1, 1, "InstallStorePluginTask_Installed".GetLocalized(PluginName));
         }

--- a/GalgameManager/Models/BgTasks/LoadPluginTask.cs
+++ b/GalgameManager/Models/BgTasks/LoadPluginTask.cs
@@ -28,7 +28,7 @@ public class LoadPluginTask : BgTaskBase
             PluginX plugin = plugins[i];
             if (plugin.ToDelete)
             {
-                DeletePlugin(plugin);
+                await DeletePlugin(plugin);
                 continue;
             }
             
@@ -47,7 +47,7 @@ public class LoadPluginTask : BgTaskBase
         ChangeProgress(1, 1, string.Empty, false);
         return;
 
-        void DeletePlugin(PluginX plugin)
+        async Task DeletePlugin(PluginX plugin)
         {
             try
             {
@@ -63,6 +63,10 @@ public class LoadPluginTask : BgTaskBase
                     if (Directory.Exists(plugin.Path)) 
                         Directory.Delete(plugin.Path, true);
                 }
+
+                // 如果出现文件占用问题，则不删除 plugin，等待下次重启再删除。
+                // 如果 plugin 自身的 OnUninstall 超时或者报错，则正常删除这个插件。
+                try { await plugin.ExecuteUninstallWithTimeoutAsync(); } catch(Exception) { /* Ignore */ }
                 if (plugin.ToDeleteData) _pluginService.PluginDeleteData(plugin);
                 db.Delete(plugin.Id);
             }

--- a/GalgameManager/Models/BgTasks/LoadPluginTask.cs
+++ b/GalgameManager/Models/BgTasks/LoadPluginTask.cs
@@ -51,9 +51,19 @@ public class LoadPluginTask : BgTaskBase
         {
             try
             {
-                if (!IsDevPlugin(plugin) && Directory.Exists(plugin.Path)) 
-                    Directory.Delete(plugin.Path, true);
-                if (plugin.ToDeleteData) dataDb.Delete(plugin.Id);
+                // 处理所有延迟删除的 Plugin，注意 dev plugin 不存在延迟删除机制。
+                if (plugin.IsDevMode)
+                {
+                    _infoService.Event(EventType.PluginError, InfoBarSeverity.Warning,
+                        "Dev Plugin Invalid State", // 标题明确指出是 Dev 插件状态异常
+                        msg: $"Dev plugin {plugin.Info.Name} found in delayed delete queue. Cleaning up...");
+                }
+                else
+                {
+                    if (Directory.Exists(plugin.Path)) 
+                        Directory.Delete(plugin.Path, true);
+                }
+                if (plugin.ToDeleteData) _pluginService.PluginDeleteData(plugin);
                 db.Delete(plugin.Id);
             }
             catch (Exception)
@@ -66,6 +76,4 @@ public class LoadPluginTask : BgTaskBase
     });
 
     public override string Title => "LoadPluginTask_Title".GetLocalized();
-    
-    private bool IsDevPlugin(PluginX plugin) => !Utils.IsPathContained(_pluginDir.FullName, plugin.Path);
 }

--- a/GalgameManager/Models/PluginX.cs
+++ b/GalgameManager/Models/PluginX.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.Loader;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using GalgameManager.Contracts.Services;
 using GalgameManager.Enums;
 using GalgameManager.Helpers;
@@ -13,7 +11,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace GalgameManager.Models;
 
-public partial class PluginX : ObservableObject
+public partial class PluginX : ObservableObject, IComparable<PluginX>
 {
     [BsonId] public Guid Id { get; init; }
     [BsonIgnore] public IPlugin? Plugin { get; set; }
@@ -72,6 +70,60 @@ public partial class PluginX : ObservableObject
                 "PluginX_UiSlow_Title".GetLocalized(), msg: "PluginX_UiSlow_Msg".GetLocalized(Info.Name));
         return ui;
     }
+
+    /// <summary>
+    /// 安全地调用插件的 OnUninstall 方法，支持最大执行时间限制及动态延时请求。
+    /// </summary>
+    /// <remarks>
+    /// 此方法会启动一个受监控的卸载任务：
+    /// <list type="bullet">
+    /// <item>默认等待时间为 5 秒。</item>
+    /// <item>插件可通过回调请求延长等待时间，但总时长不会超过 60 秒。</item>
+    /// <item>一旦超时，将自动取消任务并抛出 <see cref="TimeoutException"/>。</item>
+    /// </list>
+    /// </remarks>
+    public async Task ExecuteUninstallWithTimeoutAsync()
+    {
+        // Only wait for 5 seconds for unload to complete.
+        TimeSpan initialTimeout = TimeSpan.FromSeconds(5);
+        TimeSpan maxTimeout = TimeSpan.FromSeconds(60);
+
+        using var cts = new CancellationTokenSource();
+
+        var startTime = DateTime.UtcNow;
+        var deadline = startTime.Add(initialTimeout);
+        var hardDeadline = startTime.Add(maxTimeout);
+        cts.CancelAfter(hardDeadline - startTime);
+
+        Action<TimeSpan> extendWaitHandler = (extraTime) =>
+        {
+            DateTime newDeadline = DateTime.UtcNow.Add(extraTime);
+            if (newDeadline > hardDeadline) newDeadline = hardDeadline;
+            if (newDeadline > deadline) deadline = newDeadline;
+        };
+
+        if (Plugin is not null)
+        {
+            Task uninstallTask = Plugin.OnUninstallAsync(ToDeleteData, extendWaitHandler, cts.Token);
+            while (!uninstallTask.IsCompleted)
+            {
+                var now = DateTime.UtcNow;
+                if (now >= deadline)
+                {
+                    await cts.CancelAsync();
+                    throw new TimeoutException("Plugin Uninstall Timeout");
+                }
+
+                var waitTime = deadline - now;
+                var delayTask = Task.Delay(waitTime, cts.Token);
+                var completeTask = await Task.WhenAny(uninstallTask, delayTask);
+
+                if (completeTask == uninstallTask)
+                    break;
+            }
+            await uninstallTask;
+        }
+    }
     
     public void ForceUnload()
     {
@@ -80,6 +132,15 @@ public partial class PluginX : ObservableObject
         Plugin = null;
         LoadContext.Unload();
         LoadContext = null!;
+    }
+
+    public int CompareTo(PluginX? other) {
+        if (other is null) return 0;
+        // 优先级1: IsDevMode 降序 (true 在前)
+        var devCompare = other.IsDevMode.CompareTo(IsDevMode); 
+        if (devCompare != 0) return devCompare;
+        // 优先级2: Name 升序
+        return string.Compare(Info.Name, other.Info.Name, StringComparison.OrdinalIgnoreCase);
     }
     
     public override bool Equals(object? obj)

--- a/GalgameManager/Models/PluginX.cs
+++ b/GalgameManager/Models/PluginX.cs
@@ -1,4 +1,6 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using System.Reflection;
+using System.Runtime.Loader;
+using CommunityToolkit.Mvvm.ComponentModel;
 using GalgameManager.Contracts.Services;
 using GalgameManager.Enums;
 using GalgameManager.Helpers;
@@ -13,7 +15,7 @@ namespace GalgameManager.Models;
 
 public partial class PluginX : ObservableObject
 {
-    [BsonId] public Guid Id { get; set; }
+    [BsonId] public Guid Id { get; }
     [BsonIgnore] public IPlugin? Plugin { get; set; }
     public PluginInfo Info { get; set; } 
     [ObservableProperty] private string _path;
@@ -69,6 +71,29 @@ public partial class PluginX : ObservableObject
             App.GetService<IInfoService>().Event(EventType.PluginError, InfoBarSeverity.Informational,
                 "PluginX_UiSlow_Title".GetLocalized(), msg: "PluginX_UiSlow_Msg".GetLocalized(Info.Name));
         return ui;
+    }
+    
+    public void ForceUnload()
+    {
+        IsLoaded = false;
+        Info = null!;
+        Plugin = null;
+        LoadContext.Unload();
+        LoadContext = null!;
+    }
+    
+    public override bool Equals(object? obj)
+    {
+        if (obj is PluginX other)
+        {
+            return Id.Equals(other.Id);
+        }
+        return false;
+    }
+    
+    public override int GetHashCode()
+    {
+        return Id.GetHashCode();
     }
 }
 

--- a/GalgameManager/Models/PluginX.cs
+++ b/GalgameManager/Models/PluginX.cs
@@ -31,6 +31,10 @@ public partial class PluginX : ObservableObject
     /// 是否已经加载
     [BsonIgnore] public bool IsLoaded { get; set; } = false;
     [BsonIgnore] public PluginLoadContext LoadContext { get; set; }
+    
+    // 插件是否是在 Dev 模式下加载的
+    [ObservableProperty] private bool _isDevMode = false;
+    
     [Obsolete("For deserialization only", true)]
     public PluginX()
     {

--- a/GalgameManager/Models/PluginX.cs
+++ b/GalgameManager/Models/PluginX.cs
@@ -15,7 +15,7 @@ namespace GalgameManager.Models;
 
 public partial class PluginX : ObservableObject
 {
-    [BsonId] public Guid Id { get; }
+    [BsonId] public Guid Id { get; init; }
     [BsonIgnore] public IPlugin? Plugin { get; set; }
     public PluginInfo Info { get; set; } 
     [ObservableProperty] private string _path;

--- a/GalgameManager/Services/PluginService/PluginService.cs
+++ b/GalgameManager/Services/PluginService/PluginService.cs
@@ -15,6 +15,21 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace GalgameManager.Services;
 
+
+public class PluginComparer : IComparer<PluginX>
+{
+    public static readonly PluginComparer Instance = new();
+    public int Compare(PluginX? x, PluginX? y)
+    {
+        if (x is null || y is null) return 0;
+        // 优先级1: IsDevMode 降序 (true 在前)
+        var devCompare = y.IsDevMode.CompareTo(x.IsDevMode); 
+        if (devCompare != 0) return devCompare;
+        // 优先级2: Name 升序
+        return string.Compare(x.Info.Name, y.Info.Name, StringComparison.OrdinalIgnoreCase);
+    }
+}
+
 public partial class PluginService(
     ILocalSettingsService settingService,
     IBgTaskService bgTaskService,
@@ -23,32 +38,73 @@ public partial class PluginService(
 {
     private ObservableCollection<PluginX> _plugins = [];
     private ILiteCollection<PluginX> _pluginsDb = null!;
+    private ILiteCollection<PluginData> _pluginDataDb = null!;
 
     public bool PluginOffloadInProgress { get; private set; }
-
-    public async Task AddPluginAsync(string path)
+    
+    private void AddPluginToListSorted(PluginX plugin)
     {
+        var i = 0;
+        while (i < _plugins.Count && PluginComparer.Instance.Compare(_plugins[i], plugin) < 0)
+        {
+            i++;
+        }
+        _plugins.Insert(i, plugin);
+    }
+    
+    private void RemovePluginFromList(PluginX plugin)
+    {
+        _plugins.Remove(plugin);
+    }
+    public void PluginSetData(PluginX plugin, string? data)
+    {
+        PluginData newData = new() {
+            PluginId = plugin.Id,
+            Data = data,
+        };
+        _pluginDataDb.Upsert(newData);
+    }
+    
+    public void PluginDeleteData(PluginX plugin) => _pluginDataDb.Delete(plugin.Info.Id);
+
+    public async Task AddPluginAsync(string path, bool isDev)
+    {
+        // 如果删除过正常插件，即使是 Dev 模式也会禁止加载新的插件。
         if (PluginOffloadInProgress) 
             throw new PvnException("PluginService_PluginOffloadInProgress".GetLocalized());
         if (_plugins.Any(p => Utils.ArePathsEqual(path, p.Path)))   
             throw new PvnException($"plugin in {path} already initialized");
-        (IPlugin plugin, PluginLoadContext contex) tmp = await LoadPluginInternalAsync(path);
+        (IPlugin plugin, PluginLoadContext contex) tmp = await LoadPluginInternalAsync(path, isDev);
         PluginX plugin = new(tmp.plugin, path, tmp.contex)
         {
             Enable = true,
+            IsDevMode = isDev,
         };
         await LoadPluginAsync(plugin, true);
+        // 使用 Insert 来做最后的判重，防止重复加载 Dev 插件。
         _pluginsDb.Insert(plugin);
     }
 
     public async Task DeletePluginAsync(PluginX plugin, bool deleteData)
     {
-        await Task.CompletedTask;
-        PluginOffloadInProgress = true;
         plugin.ToDelete = true;
         plugin.ToDeleteData = deleteData;
-        await UiThreadInvokeHelper.InvokeAsync(() => _plugins.Remove(plugin));
-        SavePlugin(plugin);
+        if (!plugin.IsDevMode)
+        {
+            // 对于 Dev Plugin，我们立即删除对应的 Plugin，同时不进入 Offload phase
+            PluginOffloadInProgress = true;
+        }
+        await UiThreadInvokeHelper.InvokeAsync(() => RemovePluginFromList(plugin));
+        if (plugin.IsDevMode)
+        {
+            _pluginsDb.Delete(plugin.Id);
+            if (deleteData)
+                PluginDeleteData(plugin);
+        }
+        else
+        {
+            SavePlugin(plugin);
+        }
     }
 
     public Task<ObservableCollection<PluginX>> GetAllPluginsAsync() => Task.FromResult(_plugins);
@@ -57,6 +113,7 @@ public partial class PluginService(
     {
         await Task.CompletedTask; //预留异步
         _pluginsDb = settingService.Database.GetCollection<PluginX>("plugin");
+        _pluginDataDb = settingService.Database.GetCollection<PluginData>("plugin_data");
         PluginDir = new DirectoryInfo((await FileHelper.GetFolderAsync(FileHelper.FolderType.Plugins)).Path);
         if (!PluginDir.Exists) PluginDir.Create();
         _ = bgTaskService.AddBgTask(new LoadPluginTask());
@@ -67,15 +124,18 @@ public partial class PluginService(
         if (plugin.IsLoaded) return;
         if (load)
         {
-            (IPlugin plugin, PluginLoadContext contex) tmp = await LoadPluginInternalAsync(plugin.Path);
-            plugin.Plugin = tmp.plugin;
-            plugin.LoadContext = tmp.contex;
+            if (plugin.Plugin is null)
+            {
+                (IPlugin plugin, PluginLoadContext contex) tmp = await LoadPluginInternalAsync(plugin.Path, plugin.IsDevMode);
+                plugin.Plugin = tmp.plugin;
+                plugin.LoadContext = tmp.contex;
+            }
             plugin.Info = plugin.Plugin.Info;
             await plugin.Plugin.InitializeAsync(new PotatoVnApiHost(plugin));
             plugin.IsLoaded = true;
         }
         if (_plugins.All(p => p.Info.Id != plugin.Info.Id))
-            await UiThreadInvokeHelper.InvokeAsync(() => { _plugins.Add(plugin); });
+            await UiThreadInvokeHelper.InvokeAsync(() => AddPluginToListSorted(plugin));
         plugin.PropertyChanged -= OnPluginOnPropertyChanged;
         plugin.PropertyChanged += OnPluginOnPropertyChanged;
         if (load) bus.Send(new PluginLoadArgs { Plugin = plugin.Plugin! });
@@ -83,6 +143,7 @@ public partial class PluginService(
 
         async void OnPluginOnPropertyChanged(object? sender, PropertyChangedEventArgs args)
         {
+            // FIXME(kuriko): 这里我们没有考虑 name 和 devMode 属性变化导致的插件列表重排序问题
             try
             {
                 if (args.PropertyName != nameof(PluginX.Enable)) return;
@@ -112,7 +173,7 @@ public partial class PluginService(
             msg: msgHeader + "PluginService_PluginError_Msg".GetLocalized(e.ToString()));
     }
 
-    private static async Task<(IPlugin plugin, PluginLoadContext contex)> LoadPluginInternalAsync(string path)
+    private static async Task<(IPlugin plugin, PluginLoadContext contex)> LoadPluginInternalAsync(string path, bool isDev)
     {
         await Task.CompletedTask; //预留异步
         if (!Directory.Exists(path)) throw new PvnPathNotExist(path);
@@ -124,9 +185,26 @@ public partial class PluginService(
             pluginFile = Directory.GetFiles(path, "PotatoVN.App.PluginBase.dll").FirstOrDefault();
         if (pluginFile == null || !File.Exists(pluginFile)) 
             throw new PvnException($"plugin dll of {path} not found");
-        
         PluginLoadContext loadContext = new(pluginFile);
-        Assembly pluginAssembly = loadContext.LoadFromAssemblyPath(pluginFile);
+
+        Assembly pluginAssembly;
+        if (isDev)
+        {
+            var pdbPath = Path.ChangeExtension(pluginFile, ".pdb");
+            FileStream? pdbStream = File.Exists(pdbPath) 
+                ? new FileStream(pdbPath, FileMode.Open, FileAccess.Read, FileShare.Read) 
+                : null;
+            await using (pdbStream)
+            {
+                await using FileStream fs = new (pluginFile, FileMode.Open, FileAccess.Read);
+                pluginAssembly = loadContext.LoadFromStream(fs, pdbStream);
+            }
+        }
+        else
+        {
+            pluginAssembly = loadContext.LoadFromAssemblyPath(pluginFile);
+        }
+        
         Type? pluginType = pluginAssembly.GetTypes()
             .FirstOrDefault(t => typeof(IPlugin).IsAssignableFrom(t) && !t.IsInterface);
         if (pluginType == null) throw new PvnException($"no valid plugin found in {path}");

--- a/GalgameManager/Services/PluginService/PluginService.cs
+++ b/GalgameManager/Services/PluginService/PluginService.cs
@@ -56,6 +56,7 @@ public partial class PluginService(
     {
         _plugins.Remove(plugin);
     }
+    
     public void PluginSetData(PluginX plugin, string? data)
     {
         PluginData newData = new() {
@@ -91,20 +92,87 @@ public partial class PluginService(
         plugin.ToDeleteData = deleteData;
         if (!plugin.IsDevMode)
         {
-            // 对于 Dev Plugin，我们立即删除对应的 Plugin，同时不进入 Offload phase
+            // 对于 Dev Plugin，我们立即删除对应的 Plugin，同时不进入 Offload State
             PluginOffloadInProgress = true;
         }
-        await UiThreadInvokeHelper.InvokeAsync(() => RemovePluginFromList(plugin));
         if (plugin.IsDevMode)
         {
-            _pluginsDb.Delete(plugin.Id);
+            try
+            {
+                // Only wait for 5 seconds for unload to complete.
+                TimeSpan initialTimeout = TimeSpan.FromSeconds(5);
+                TimeSpan maxTimeout = TimeSpan.FromSeconds(60);
+
+                using var cts = new CancellationTokenSource();
+
+                var startTime = DateTime.UtcNow;
+                var deadline = startTime.Add(initialTimeout);
+                var hardDeadline = startTime.Add(maxTimeout);
+                cts.CancelAfter(hardDeadline - startTime);
+
+                Action<TimeSpan> extendWaitHandler = (extraTime) =>
+                {
+                    DateTime newDeadline = DateTime.UtcNow.Add(extraTime);
+                    if (newDeadline > hardDeadline) newDeadline = hardDeadline;
+                    if (newDeadline > deadline) deadline = newDeadline;
+                };
+
+                if (plugin.Plugin is not null)
+                {
+                    Task uninstallTask = plugin.Plugin.OnUninstallAsync(deleteData, extendWaitHandler, cts.Token);
+                    while (!uninstallTask.IsCompleted)
+                    {
+                        var now = DateTime.UtcNow;
+                        if (now >= deadline)
+                        {
+                            await cts.CancelAsync();
+                            throw new TimeoutException("Plugin Uninstall Timeout");
+                        }
+
+                        var waitTime = deadline - now;
+                        var delayTask = Task.Delay(waitTime, cts.Token);
+                        var completeTask = await Task.WhenAny(uninstallTask, delayTask);
+
+                        if (completeTask == uninstallTask)
+                            break;
+                    }
+                    await uninstallTask;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                /* 插件内部中止操作 */
+                App.GetService<IInfoService>().Event(EventType.PluginError, InfoBarSeverity.Warning,
+                    $"Abort",
+                    msg: $"Dev plugin {plugin.Info.Name} uninstalled internal abort"
+                );
+            }
+            catch (TimeoutException)
+            {
+                /* 卸载超时：硬超时 */
+                App.GetService<IInfoService>().Event(EventType.PluginError, InfoBarSeverity.Warning,
+                    $"Timeout",
+                    msg: $"Dev plugin {plugin.Info.Name} uninstalled timeout"
+                );
+            }
+            catch (Exception e)
+            {
+                 /* 卸载错误 */
+                 App.GetService<IInfoService>().Event(EventType.PluginError, InfoBarSeverity.Warning,
+                 $"Dev plugin {plugin.Info.Name} uninstalled with errors",
+                 msg: $"Dev plugin {plugin.Info.Name} uninstalled with errors...\n${e}"
+                 );
+            }
+            _pluginsDb.Delete(plugin.Info.Id);
             if (deleteData)
                 PluginDeleteData(plugin);
+            plugin.ForceUnload();
         }
         else
         {
             SavePlugin(plugin);
         }
+        await UiThreadInvokeHelper.InvokeAsync(() => RemovePluginFromList(plugin));
     }
 
     public Task<ObservableCollection<PluginX>> GetAllPluginsAsync() => Task.FromResult(_plugins);

--- a/GalgameManager/Services/PluginService/PluginService.cs
+++ b/GalgameManager/Services/PluginService/PluginService.cs
@@ -16,19 +16,6 @@ using Microsoft.UI.Xaml.Controls;
 namespace GalgameManager.Services;
 
 
-public class PluginComparer : IComparer<PluginX>
-{
-    public static readonly PluginComparer Instance = new();
-    public int Compare(PluginX? x, PluginX? y)
-    {
-        if (x is null || y is null) return 0;
-        // 优先级1: IsDevMode 降序 (true 在前)
-        var devCompare = y.IsDevMode.CompareTo(x.IsDevMode); 
-        if (devCompare != 0) return devCompare;
-        // 优先级2: Name 升序
-        return string.Compare(x.Info.Name, y.Info.Name, StringComparison.OrdinalIgnoreCase);
-    }
-}
 
 public partial class PluginService(
     ILocalSettingsService settingService,
@@ -41,21 +28,6 @@ public partial class PluginService(
     private ILiteCollection<PluginData> _pluginDataDb = null!;
 
     public bool PluginOffloadInProgress { get; private set; }
-    
-    private void AddPluginToListSorted(PluginX plugin)
-    {
-        var i = 0;
-        while (i < _plugins.Count && PluginComparer.Instance.Compare(_plugins[i], plugin) < 0)
-        {
-            i++;
-        }
-        _plugins.Insert(i, plugin);
-    }
-    
-    private void RemovePluginFromList(PluginX plugin)
-    {
-        _plugins.Remove(plugin);
-    }
     
     public void PluginSetData(PluginX plugin, string? data)
     {
@@ -86,6 +58,38 @@ public partial class PluginService(
         _pluginsDb.Insert(plugin);
     }
 
+    public async Task InvokePluginOnUninstall(PluginX plugin)
+    {
+        try
+        {
+            await plugin.ExecuteUninstallWithTimeoutAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            /* 插件内部中止操作 */
+            App.GetService<IInfoService>().Event(EventType.PluginError, InfoBarSeverity.Warning,
+                $"Abort",
+                msg: $"Dev plugin {plugin.Info.Name} uninstalled internal abort"
+            );
+        }
+        catch (TimeoutException)
+        {
+            /* 卸载超时：硬超时 */
+            App.GetService<IInfoService>().Event(EventType.PluginError, InfoBarSeverity.Warning,
+                $"Timeout",
+                msg: $"Dev plugin {plugin.Info.Name} uninstalled timeout"
+            );
+        }
+        catch (Exception e)
+        {
+            /* 卸载错误 */
+            App.GetService<IInfoService>().Event(EventType.PluginError, InfoBarSeverity.Warning,
+                $"Dev plugin {plugin.Info.Name} uninstalled with errors",
+                msg: $"Dev plugin {plugin.Info.Name} uninstalled with errors...\n${e}"
+            );
+        }
+    }
+    
     public async Task DeletePluginAsync(PluginX plugin, bool deleteData)
     {
         plugin.ToDelete = true;
@@ -97,72 +101,7 @@ public partial class PluginService(
         }
         if (plugin.IsDevMode)
         {
-            try
-            {
-                // Only wait for 5 seconds for unload to complete.
-                TimeSpan initialTimeout = TimeSpan.FromSeconds(5);
-                TimeSpan maxTimeout = TimeSpan.FromSeconds(60);
-
-                using var cts = new CancellationTokenSource();
-
-                var startTime = DateTime.UtcNow;
-                var deadline = startTime.Add(initialTimeout);
-                var hardDeadline = startTime.Add(maxTimeout);
-                cts.CancelAfter(hardDeadline - startTime);
-
-                Action<TimeSpan> extendWaitHandler = (extraTime) =>
-                {
-                    DateTime newDeadline = DateTime.UtcNow.Add(extraTime);
-                    if (newDeadline > hardDeadline) newDeadline = hardDeadline;
-                    if (newDeadline > deadline) deadline = newDeadline;
-                };
-
-                if (plugin.Plugin is not null)
-                {
-                    Task uninstallTask = plugin.Plugin.OnUninstallAsync(deleteData, extendWaitHandler, cts.Token);
-                    while (!uninstallTask.IsCompleted)
-                    {
-                        var now = DateTime.UtcNow;
-                        if (now >= deadline)
-                        {
-                            await cts.CancelAsync();
-                            throw new TimeoutException("Plugin Uninstall Timeout");
-                        }
-
-                        var waitTime = deadline - now;
-                        var delayTask = Task.Delay(waitTime, cts.Token);
-                        var completeTask = await Task.WhenAny(uninstallTask, delayTask);
-
-                        if (completeTask == uninstallTask)
-                            break;
-                    }
-                    await uninstallTask;
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                /* 插件内部中止操作 */
-                App.GetService<IInfoService>().Event(EventType.PluginError, InfoBarSeverity.Warning,
-                    $"Abort",
-                    msg: $"Dev plugin {plugin.Info.Name} uninstalled internal abort"
-                );
-            }
-            catch (TimeoutException)
-            {
-                /* 卸载超时：硬超时 */
-                App.GetService<IInfoService>().Event(EventType.PluginError, InfoBarSeverity.Warning,
-                    $"Timeout",
-                    msg: $"Dev plugin {plugin.Info.Name} uninstalled timeout"
-                );
-            }
-            catch (Exception e)
-            {
-                 /* 卸载错误 */
-                 App.GetService<IInfoService>().Event(EventType.PluginError, InfoBarSeverity.Warning,
-                 $"Dev plugin {plugin.Info.Name} uninstalled with errors",
-                 msg: $"Dev plugin {plugin.Info.Name} uninstalled with errors...\n${e}"
-                 );
-            }
+            await InvokePluginOnUninstall(plugin);
             _pluginsDb.Delete(plugin.Info.Id);
             if (deleteData)
                 PluginDeleteData(plugin);
@@ -172,7 +111,7 @@ public partial class PluginService(
         {
             SavePlugin(plugin);
         }
-        await UiThreadInvokeHelper.InvokeAsync(() => RemovePluginFromList(plugin));
+        await UiThreadInvokeHelper.InvokeAsync(() => _plugins.Remove(plugin));
     }
 
     public Task<ObservableCollection<PluginX>> GetAllPluginsAsync() => Task.FromResult(_plugins);
@@ -203,7 +142,7 @@ public partial class PluginService(
             plugin.IsLoaded = true;
         }
         if (_plugins.All(p => p.Info.Id != plugin.Info.Id))
-            await UiThreadInvokeHelper.InvokeAsync(() => AddPluginToListSorted(plugin));
+            await UiThreadInvokeHelper.InvokeAsync(() => _plugins.Add(plugin));
         plugin.PropertyChanged -= OnPluginOnPropertyChanged;
         plugin.PropertyChanged += OnPluginOnPropertyChanged;
         if (load) bus.Send(new PluginLoadArgs { Plugin = plugin.Plugin! });
@@ -211,7 +150,6 @@ public partial class PluginService(
 
         async void OnPluginOnPropertyChanged(object? sender, PropertyChangedEventArgs args)
         {
-            // FIXME(kuriko): 这里我们没有考虑 name 和 devMode 属性变化导致的插件列表重排序问题
             try
             {
                 if (args.PropertyName != nameof(PluginX.Enable)) return;

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -4441,4 +4441,16 @@
   <data name="InstallStorePluginTask_Installed" xml:space="preserve">
     <value>插件{0}已完成安装并启用</value>
   </data>
+  <data name="PluginPage_HotReloadDialog_DeleteData" xml:space="preserve">
+    <value>同时删除插件数据</value>
+  </data>
+  <data name="PluginPage_HotReloadDialog_Yes" xml:space="preserve">
+    <value>热重载</value>
+  </data>
+  <data name="PluginPage_UninstallPlugin_HotReloadButton.Content" xml:space="preserve">
+    <value>热重载</value>
+  </data>
+  <data name="PluginPage_HotReloadDialog_Title" xml:space="preserve">
+    <value>热重载插件</value>
+  </data>
 </root>

--- a/GalgameManager/ViewModels/PluginViewModel.cs
+++ b/GalgameManager/ViewModels/PluginViewModel.cs
@@ -42,7 +42,7 @@ public partial class PluginViewModel(IPluginService pluginService, IInfoService 
     }
 
     [RelayCommand]
-    private async Task AddPluginDev()
+    private async Task AddPluginFromDev()
     {
         try
         {
@@ -51,7 +51,7 @@ public partial class PluginViewModel(IPluginService pluginService, IInfoService 
             WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, App.MainWindow!.GetWindowHandle());
             StorageFolder? folder = await folderPicker.PickSingleFolderAsync();
             if (folder is null) return;
-            await pluginService.AddPluginAsync(folder.Path);
+            await pluginService.AddPluginAsync(folder.Path, true);
         }
         catch (Exception e)
         {
@@ -61,7 +61,7 @@ public partial class PluginViewModel(IPluginService pluginService, IInfoService 
     }
 
     [RelayCommand]
-    private void AddPlugin()
+    private void AddPluginFromStore()
     {
         navService.NavigateTo(typeof(PluginStoreViewModel).FullName!);
     }
@@ -115,5 +115,18 @@ public partial class PluginSettingViewModel (PluginX plugin, IPluginService plug
         await dialog.ShowAsync();
         if (!dialog.PrimaryButtonClicked) return;
         await pluginService.DeletePluginAsync(Plugin, dialog.CheckBoxChecked);
+    }
+    
+    [RelayCommand]
+    private async Task HotReloadDevPlugin()
+    {
+        BasicDialog dialog = new("PluginPage_HotReloadDialog_Title".GetLocalized(),
+            checkBoxText: "PluginPage_HotReloadDialog_DeleteData".GetLocalized(),
+            primaryButton: "PluginPage_HotReloadDialog_Yes".GetLocalized());
+        await dialog.ShowAsync();
+        if (!dialog.PrimaryButtonClicked) return;
+        var pluginPath = Plugin.Path;
+        await pluginService.DeletePluginAsync(Plugin, dialog.CheckBoxChecked);
+        await pluginService.AddPluginAsync(pluginPath, true);
     }
 }

--- a/GalgameManager/ViewModels/PluginViewModel.cs
+++ b/GalgameManager/ViewModels/PluginViewModel.cs
@@ -70,9 +70,12 @@ public partial class PluginViewModel(IPluginService pluginService, IInfoService 
     {
         try
         {
+            ObservableCollection<PluginX> sourcePlugins = await pluginService.GetAllPluginsAsync();
+            List<PluginX> pluginsSorted = sourcePlugins.ToList();
+            pluginsSorted.Sort();
+            
             Plugins.Clear();
-            ObservableCollection<PluginX> tmp = await pluginService.GetAllPluginsAsync();
-            foreach (PluginX plugin in tmp)
+            foreach (PluginX plugin in pluginsSorted)
                 Plugins.Add(new PluginSettingViewModel(plugin, pluginService));
         }
         catch (Exception ex)

--- a/GalgameManager/Views/PluginPage.xaml
+++ b/GalgameManager/Views/PluginPage.xaml
@@ -16,14 +16,14 @@
 
         <CommandBar Grid.Row="0" Background="Transparent" IsOpen="False" DefaultLabelPosition="Right"
                     Margin="{StaticResource CommandBarMargin}">
-            <AppBarButton x:Uid="PluginPage_Add" Command="{x:Bind ViewModel.AddPluginCommand}">
+            <AppBarButton x:Uid="PluginPage_Add" Command="{x:Bind ViewModel.AddPluginFromStoreCommand}">
                 <AppBarButton.Icon>
-                    <control:ConditionalFontIcon Symbol="Add" FluentGlyph="&#xE710;"/>
+                    <control:ConditionalFontIcon Symbol="Add" FluentGlyph="&#xE710;" />
                 </AppBarButton.Icon>
             </AppBarButton>
-            <AppBarButton x:Uid="PluginPage_Add_Dev" Command="{x:Bind ViewModel.AddPluginDevCommand}">
+            <AppBarButton x:Uid="PluginPage_Add_Dev" Command="{x:Bind ViewModel.AddPluginFromDevCommand}">
                 <AppBarButton.Icon>
-                    <control:ConditionalFontIcon Symbol="Add" FluentGlyph="&#xE710;"/>
+                    <control:ConditionalFontIcon Symbol="Add" FluentGlyph="&#xE710;" />
                 </AppBarButton.Icon>
             </AppBarButton>
         </CommandBar>
@@ -36,16 +36,16 @@
                             <Expander HorizontalContentAlignment="Stretch" HorizontalAlignment="Stretch"
                                       IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}">
                                 <Expander.Header>
-                                    <Grid ColumnDefinitions="*, Auto"  Padding=" 0 10">
+                                    <Grid ColumnDefinitions="*, Auto" Padding=" 0 10">
                                         <StackPanel Grid.Column="0">
-                                            <TextBlock Text="{x:Bind Plugin.Info.Name}"/>
+                                            <TextBlock Text="{x:Bind Plugin.Info.Name}" />
                                             <TextBlock
                                                 Text="{x:Bind Plugin.Info.Description}"
-                                                Style="{StaticResource DescriptionTextStyle}"/>
+                                                Style="{StaticResource DescriptionTextStyle}" />
                                         </StackPanel>
                                         <ToggleSwitch Grid.Column="1" x:Uid="PluginPage_PluginStatus"
                                                       IsOn="{x:Bind Plugin.Enable, Mode=TwoWay}"
-                                                      Margin="0 0 -20 0"/>
+                                                      Margin="0 0 -20 0" />
                                     </Grid>
                                 </Expander.Header>
                                 <Expander.Content>
@@ -53,13 +53,23 @@
                                         <ContentPresenter Content="{x:Bind Ui, Mode=OneWay}" />
                                         <control:Panel>
                                             <control:Setting x:Uid="PluginPage_UninstallPlugin">
-                                                <Button x:Uid="PluginPage_UninstallPlugin_Button" 
-                                                        Command="{x:Bind DeletePluginCommand}"/>
+                                                <StackPanel Orientation="Horizontal" Spacing="10">
+                                                    <Button x:Uid="PluginPage_UninstallPlugin_HotReloadButton"
+                                                            Visibility="{x:Bind Plugin.IsDevMode, Mode=OneWay}"
+                                                            Command="{x:Bind HotReloadDevPluginCommand}" />
+                                                    <Button x:Uid="PluginPage_UninstallPlugin_Button"
+                                                            Command="{x:Bind DeletePluginCommand}" />
+                                                </StackPanel>
                                             </control:Setting>
                                         </control:Panel>
                                     </StackPanel>
                                 </Expander.Content>
                             </Expander>
+                            <Border BorderBrush="#c864a6"
+                                    BorderThickness="2"
+                                    CornerRadius="4"
+                                    IsHitTestVisible="False"
+                                    Visibility="{x:Bind Plugin.IsDevMode, Mode=OneWay}" />
                         </Grid>
                     </DataTemplate>
                 </ItemsRepeater.ItemTemplate>


### PR DESCRIPTION
这个 feature 先存疑叭。

设计上是将所有的 dev plugin 加载到内存中，防止占用文件（重启后自动删除）。
这样子可以避免重启应用，热重载开发模式的 plugin。

可能的问题：
1. dev mode 加载的插件存储的数据不会自动删除（可以添加一个 database cleanup task，启动的时候自动扫描所有无关联 plugin 的数据并删除）
2. 如果 plugin 启动了持久的 bgtask，这些 task 不会被 cancel（这一点应该在开发者手册里面写明，有持久性任务的 plugin 必须冷重启应用之类的）