### PR TITLE
feat(app): 添加游戏引擎字段支持

### DIFF
--- a/GalgameManager.WinApp.Base/Models/Galgame.cs
+++ b/GalgameManager.WinApp.Base/Models/Galgame.cs
@@ -63,6 +63,7 @@ public partial class Galgame : ObservableObject, IDisplayableGameObject
     [ObservableProperty] private LockableProperty<string> _chineseName = "";
     [ObservableProperty] private LockableProperty<string> _description = "";
     [ObservableProperty] private LockableProperty<string> _developer = DefaultString;
+    [ObservableProperty] private LockableProperty<string> _engine = DefaultString;
     [ObservableProperty] private DateTime _lastPlayTime = DateTime.MinValue; //上次游玩时间（新）
     [ObservableProperty] private LockableProperty<string> _expectedPlayTime = DefaultString;
     [ObservableProperty] private LockableProperty<float> _rating = 0;

--- a/GalgameManager/Contracts/Services/ICategoryService.cs
+++ b/GalgameManager/Contracts/Services/ICategoryService.cs
@@ -19,6 +19,11 @@ public interface ICategoryService
     /// 开发商分类组
     /// </summary>
     public CategoryGroup DeveloperGroup { get; }
+
+    /// <summary>
+    /// 游戏引擎分类组
+    /// </summary>
+    public CategoryGroup EngineGroup { get; }
     
     public Task Init();
 
@@ -83,6 +88,13 @@ public interface ICategoryService
     /// <param name="galgame"></param>
     /// <returns></returns>
     Category? GetDeveloperCategory(Galgame galgame);
+
+    /// <summary>
+    /// 获取某个游戏的游戏引擎分类，若没有则返回null
+    /// </summary>
+    /// <param name="galgame"></param>
+    /// <returns></returns>
+    Category? GetEngineCategory(Galgame galgame);
 
     /// <summary>
     /// 保存分类信息

--- a/GalgameManager/Enums/CategoryGroupType.cs
+++ b/GalgameManager/Enums/CategoryGroupType.cs
@@ -3,6 +3,7 @@
 public enum CategoryGroupType
 {
     Developer,
+    Engine,
     Status,
     Custom
 }

--- a/GalgameManager/Enums/CategoryGroupType.cs
+++ b/GalgameManager/Enums/CategoryGroupType.cs
@@ -1,9 +1,9 @@
-﻿namespace GalgameManager.Enums;
+namespace GalgameManager.Enums;
 
 public enum CategoryGroupType
 {
     Developer,
-    Engine,
     Status,
-    Custom
+    Custom,
+    Engine
 }

--- a/GalgameManager/Helpers/API/VndbApiModels.cs
+++ b/GalgameManager/Helpers/API/VndbApiModels.cs
@@ -98,6 +98,7 @@ public class VndbVn
 public class VndbRelease
 {
     public string? Id { get; set; }
+    public string? Engine { get; set; }
     public List<VndbLanguage>? Languages { get; set; }
     public List<VndbVn>? Vns { get; set; }
     public List<VndbProducer>? Producers { get; set; }
@@ -267,6 +268,18 @@ public class VndbFilters
     public static VndbFilters NotEqual(string name, string value)
     {
         JArray jsonArray = new(name, "!=", value);
+        return new VndbFilters(jsonArray);
+    }
+
+    public static VndbFilters Equal(string name, bool value)
+    {
+        JArray jsonArray = new(name, "=", value);
+        return new VndbFilters(jsonArray);
+    }
+
+    public static VndbFilters NotEqual(string name, object? value)
+    {
+        JArray jsonArray = new(name, "!=", value ?? JValue.CreateNull());
         return new VndbFilters(jsonArray);
     }
 

--- a/GalgameManager/Helpers/Converter/DefaultStringToVisibilityConverter.cs
+++ b/GalgameManager/Helpers/Converter/DefaultStringToVisibilityConverter.cs
@@ -11,7 +11,7 @@ public class DefaultStringToVisibilityConverter : IValueConverter
         if (value is not string str)
             return Visibility.Collapsed;
 
-        return string.IsNullOrEmpty(str) || str == Galgame.DefaultString
+        return string.IsNullOrWhiteSpace(str) || str == Galgame.DefaultString
             ? Visibility.Collapsed
             : Visibility.Visible;
     }

--- a/GalgameManager/Helpers/Converter/DefaultStringToVisibilityConverter.cs
+++ b/GalgameManager/Helpers/Converter/DefaultStringToVisibilityConverter.cs
@@ -1,0 +1,23 @@
+using GalgameManager.Models;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace GalgameManager.Helpers.Converter;
+
+public class DefaultStringToVisibilityConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, string language)
+    {
+        if (value is not string str)
+            return Visibility.Collapsed;
+
+        return string.IsNullOrEmpty(str) || str == Galgame.DefaultString
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/GalgameManager/Helpers/Phrase/MixedPhraser.cs
+++ b/GalgameManager/Helpers/Phrase/MixedPhraser.cs
@@ -243,6 +243,13 @@ public class MixedPhraser : IGalInfoPhraser, IGalCharacterPhraser, IGalStaffPars
                     result.Developer = tmp;
             }
         }
+        // engine
+        if (_data.Enabled.EngineEnabled)
+        {
+            result.Engine = GetValue(metas, nameof(Galgame.Engine),
+                meta => CheckStr(meta.Engine),
+                new LockableProperty<string>(Galgame.DefaultString));
+        }
 
         _bus?.Send(new GalgameParsingEventArgs(galgame, "done!"));
         return result;
@@ -381,7 +388,7 @@ public class MixedPhraserOrder
 {
     // 版本号，每次添加新搜刮器/添加新字段的时候都应该把这个数字+1，以便galgameCollectionService能够更新配置中已有的顺序配置
     // 更新配置不需要手动编写，已经在GalgameCollectionService中使用反射实现，会自动添加新的默认配置
-    public const int Version = 12;
+    public const int Version = 13;
     
     // 为什么使用ObservableCollection：为了能够在MixedPhraserOrderDialog中使顺序能够drag&drop
     // 所有变量都应该命名为：{字段名}Order，此处字段名应该与Galgame中对应的字段名一致（为了让GetValue中的反射能够找到对应的字段）
@@ -394,6 +401,7 @@ public class MixedPhraserOrder
     public ObservableCollection<RssType> CharactersOrder { get; set; } = new();
     public ObservableCollection<RssType> CnNameOrder { get; set; } = new();
     public ObservableCollection<RssType> DeveloperOrder { get; set; } = new();
+    public ObservableCollection<RssType> EngineOrder { get; set; } = new();
     public ObservableCollection<RssType> TagsOrder { get; set; } = new();
     public ObservableCollection<RssType> StaffOrder { get; set; } = new();
 
@@ -412,6 +420,7 @@ public class MixedPhraserOrder
             CharactersOrder = new() { RssType.Bangumi, RssType.Ymgal, RssType.Vndb };
             CnNameOrder = new() { RssType.Bangumi, RssType.Ymgal, RssType.Vndb };
             DeveloperOrder = new() { RssType.Bangumi, RssType.Ymgal, RssType.Vndb, RssType.Steam };
+            EngineOrder = new() { RssType.Vndb };
             TagsOrder = new() { RssType.Bangumi, RssType.Vndb, RssType.Steam };
             StaffOrder = new() { RssType.Bangumi, RssType.Ymgal, RssType.Vndb };
         }
@@ -427,6 +436,7 @@ public class MixedPhraserOrder
             CharactersOrder = new() { RssType.Vndb, RssType.Ymgal, RssType.Bangumi };
             CnNameOrder = new() { RssType.Vndb, RssType.Ymgal, RssType.Bangumi };
             DeveloperOrder = new() { RssType.Vndb, RssType.Steam, RssType.Ymgal, RssType.Bangumi };
+            EngineOrder = new() { RssType.Vndb };
             TagsOrder = new() { RssType.Vndb, RssType.Steam, RssType.Bangumi };
             StaffOrder = new() { RssType.Vndb, RssType.Ymgal, RssType.Bangumi };
         }
@@ -447,11 +457,12 @@ public class MixedPhraserEnabled
     public bool VndbEnabled { get; set; } = true;
     public bool YmgalEnabled { get; set; } = true;
     public bool SteamEnabled { get; set; } = true;
-    
+
     // Information type scraping toggles
     public bool NameEnabled { get; set; } = true;
     public bool DescriptionEnabled { get; set; } = true;
     public bool DeveloperEnabled { get; set; } = true;
+    public bool EngineEnabled { get; set; } = true;
     public bool TagsEnabled { get; set; } = true;
     public bool RatingEnabled { get; set; } = true;
     public bool ExpectedPlayTimeEnabled { get; set; } = true;

--- a/GalgameManager/Helpers/Phrase/VndbPhraser.cs
+++ b/GalgameManager/Helpers/Phrase/VndbPhraser.cs
@@ -585,7 +585,6 @@ public class VndbPhraser : IGalInfoPhraser, IGalStatusSync, IGalCharacterPhraser
             if (response.Results == null || response.Results.Count == 0) return null;
             // 返回第一个有引擎值的记录
             var engine = response.Results.FirstOrDefault(r => !string.IsNullOrEmpty(r.Engine))?.Engine;
-            System.Diagnostics.Debug.WriteLine($"GetEngineAsync: Selected engine='{engine ?? "null"}'");
             return engine;
         }
         catch (Exception e)

--- a/GalgameManager/Helpers/Phrase/VndbPhraser.cs
+++ b/GalgameManager/Helpers/Phrase/VndbPhraser.cs
@@ -235,6 +235,17 @@ public class VndbPhraser : IGalInfoPhraser, IGalStatusSync, IGalCharacterPhraser
             result.ReleaseDate = (rssItem.Released != null
                 ? IGalInfoPhraser.GetDateTimeFromString(rssItem.Released)
                 : null) ?? DateTime.MinValue;
+            // Engine
+            var vnIdForEngine = id.StartsWith("v") ? id : "v" + id;
+            try
+            {
+                var engine = await GetEngineAsync(vnIdForEngine);
+                result.Engine.Value = engine ?? string.Empty;
+            }
+            catch (Exception)
+            {
+                result.Engine.Value = string.Empty;
+            }
             // Tags
             result.Tags.Value = new ObservableCollection<string>();
             if (rssItem.Tags != null)
@@ -546,6 +557,42 @@ public class VndbPhraser : IGalInfoPhraser, IGalStatusSync, IGalCharacterPhraser
             if (e is not ThrottledException || retry) return null;
             await Task.Delay(60 * 1000); // 1 minute
             return await GetReleaseAsync(releaseId, true);
+        }
+    }
+
+    /// <summary>
+    /// 获取游戏引擎信息
+    /// </summary>
+    private async Task<string?> GetEngineAsync(string? vnId, bool retry = false)
+    {
+        if (string.IsNullOrEmpty(vnId)) return null;
+        try
+        {
+            VndbResponse<VndbRelease> response = await _vndbApi.GetReleaseAsync(new VndbQuery
+            {
+                Fields = "engine",
+                Filters = VndbFilters.And(
+                    VndbFilters.Equal("vn", VndbFilters.Equal("id", vnId)),
+                    VndbFilters.Equal("official", true),
+                    VndbFilters.Equal("platform", "win"),
+                    VndbFilters.NotEqual("released", "TBA"),
+                    VndbFilters.Equal("rtype", "complete")
+                ),
+                Results = 100,
+                Sort = "released",
+                Reverse = true
+            });
+            if (response.Results == null || response.Results.Count == 0) return null;
+            // 返回第一个有引擎值的记录
+            var engine = response.Results.FirstOrDefault(r => !string.IsNullOrEmpty(r.Engine))?.Engine;
+            System.Diagnostics.Debug.WriteLine($"GetEngineAsync: Selected engine='{engine ?? "null"}'");
+            return engine;
+        }
+        catch (Exception e)
+        {
+            if (e is not ThrottledException || retry) return null;
+            await Task.Delay(60 * 1000); // 1 minute
+            return await GetEngineAsync(vnId, true);
         }
     }
 

--- a/GalgameManager/Services/CategoryService.cs
+++ b/GalgameManager/Services/CategoryService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.WinUI;
@@ -329,7 +329,7 @@ public class CategoryService : ICategoryService
         }
         // 更新引擎分类组
         if (updateEngine && await _localSettings.ReadSettingAsync<bool>(KeyValues.AutoCategory)
-            && !string.IsNullOrEmpty(galgame.Engine.Value))
+            && !string.IsNullOrWhiteSpace(galgame.Engine.Value) && galgame.Engine.Value != Galgame.DefaultString)
         {
             //移除旧的引擎分类
             Category? old = GetEngineCategory(galgame);

--- a/GalgameManager/Services/CategoryService.cs
+++ b/GalgameManager/Services/CategoryService.cs
@@ -18,7 +18,7 @@ public class CategoryService : ICategoryService
     private ObservableCollection<CategoryGroup> _categoryGroups = new();
     private readonly GalgameCollectionService _galgameService;
     private readonly IInfoService _infoService;
-    private CategoryGroup? _developerGroup, _statusGroup;
+    private CategoryGroup? _developerGroup, _statusGroup, _engineGroup;
     private readonly Category[] _statusCategory = new Category[6];
     private bool _isInit;
     private readonly ILocalSettingsService _localSettings;
@@ -33,6 +33,7 @@ public class CategoryService : ICategoryService
 
     public CategoryGroup StatusGroup => _statusGroup!;
     public CategoryGroup DeveloperGroup => _developerGroup!;
+    public CategoryGroup EngineGroup => _engineGroup!;
 
     public CategoryService(ILocalSettingsService localSettings, IGalgameCollectionService galgameService,
         IInfoService infoService, IMessenger bus)
@@ -63,6 +64,7 @@ public class CategoryService : ICategoryService
 
         InitStatusGroup();
         InitDeveloperGroup();
+        InitEngineGroup();
 
         foreach (Galgame g in _galgameService.Galgames)
             g.GalPropertyChanged += HandleGalPropertyChanged;
@@ -71,11 +73,15 @@ public class CategoryService : ICategoryService
             if (_isInit == false) return;
             galgame.GalPropertyChanged += HandleGalPropertyChanged;
             HandleGalPropertyChanged(galgame, nameof(Galgame.Developer), galgame.Developer.Value);
+            HandleGalPropertyChanged(galgame, nameof(Galgame.Engine), galgame.Engine.Value);
             HandleGalPropertyChanged(galgame, nameof(Galgame.PlayType), galgame.PlayType);
             HandleGalPropertyChanged(galgame, nameof(Galgame.LastPlayTime), galgame.LastPlayTime);
         };
         _galgameService.GalgameChangedEvent += galgame =>
+        {
             HandleGalPropertyChanged(galgame, nameof(Galgame.Developer), galgame.Developer.Value);
+            HandleGalPropertyChanged(galgame, nameof(Galgame.Engine), galgame.Engine.Value);
+        };
         _galgameService.GalgameDeletedEvent += galgame =>
         {
             galgame.GalPropertyChanged -= HandleGalPropertyChanged;
@@ -104,6 +110,9 @@ public class CategoryService : ICategoryService
             {
                 case nameof(Galgame.Developer):
                     Task __ = UpdateCategory(gal, updateDeveloper: true);
+                    break;
+                case nameof(Galgame.Engine):
+                    Task ____ = UpdateCategory(gal, updateEngine: true);
                     break;
                 case nameof(Galgame.PlayType):
                     Task ___ = UpdateCategory(gal, updateStatus: true);
@@ -262,7 +271,7 @@ public class CategoryService : ICategoryService
     {
         IList<Galgame> games = _galgameService.Galgames;
         foreach (Galgame game in games)
-            await UpdateCategory(game, updateDeveloper: true, updateStatus: true);
+            await UpdateCategory(game, updateDeveloper: true, updateStatus: true, updateEngine: true);
         //todo:空Category删除
     }
 
@@ -272,7 +281,7 @@ public class CategoryService : ICategoryService
     /// <param name="galgame">游戏</param>
     /// <param name="updateDeveloper">是否根据开发商信息更新开发商分类组</param>
     /// <param name="updateStatus">是否根据游玩状态信息更新游玩状态分类组</param>
-    private async Task UpdateCategory(Galgame galgame, bool updateDeveloper = false, bool updateStatus = false)
+    private async Task UpdateCategory(Galgame galgame, bool updateDeveloper = false, bool updateStatus = false, bool updateEngine = false)
     {
         if (_isInit == false) await Init();
         // 更新开发商分类组
@@ -317,6 +326,30 @@ public class CategoryService : ICategoryService
             }
             _statusCategory[(int)galgame.PlayType].Add(galgame);
             Save(category: _statusCategory[(int)galgame.PlayType]);
+        }
+        // 更新引擎分类组
+        if (updateEngine && await _localSettings.ReadSettingAsync<bool>(KeyValues.AutoCategory)
+            && !string.IsNullOrEmpty(galgame.Engine.Value))
+        {
+            //移除旧的引擎分类
+            Category? old = GetEngineCategory(galgame);
+            if (old is not null)
+            {
+                old.Remove(galgame);
+                Save(category: old);
+            }
+
+            var engineString = galgame.Engine.Value!;
+            Category? engine = _engineGroup!.Categories.FirstOrDefault(c =>
+                string.Equals(c.Name, engineString, StringComparison.CurrentCultureIgnoreCase));
+            if (engine is null)
+            {
+                engine = new Category(engineString);
+                Save(category: engine);
+                AddCategoryToGroup(_engineGroup!, engine);
+            }
+            engine.Add(galgame);
+            Save(category: engine);
         }
 
     }
@@ -406,6 +439,17 @@ public class CategoryService : ICategoryService
     {
         foreach(Category category in galgame.Categories)
             if(_developerGroup!.Categories.Contains(category))
+                return category;
+        return null;
+    }
+
+    /// <summary>
+    /// 获取引擎分类，如果没有则返回null
+    /// </summary>
+    public Category? GetEngineCategory(Galgame galgame)
+    {
+        foreach(Category category in galgame.Categories)
+            if(_engineGroup!.Categories.Contains(category))
                 return category;
         return null;
     }
@@ -504,6 +548,22 @@ public class CategoryService : ICategoryService
                 CategoryGroupType.Developer);
             _categoryGroups.Add(_developerGroup);
             Save(categoryGroup: _developerGroup);
+        }
+    }
+
+    private void InitEngineGroup()
+    {
+        try
+        {
+            _engineGroup = _categoryGroups.First(cg => cg.Type == CategoryGroupType.Engine);
+            _engineGroup.Name = ResourceExtensions.GetLocalized("CategoryService_Engine");
+        }
+        catch
+        {
+            _engineGroup = new CategoryGroup(ResourceExtensions.GetLocalized("CategoryService_Engine"),
+                CategoryGroupType.Engine);
+            _categoryGroups.Add(_engineGroup);
+            Save(categoryGroup: _engineGroup);
         }
     }
 

--- a/GalgameManager/Services/GalgameCollectionService/GalgameCollectionService.cs
+++ b/GalgameManager/Services/GalgameCollectionService/GalgameCollectionService.cs
@@ -412,6 +412,8 @@ public partial class GalgameCollectionService : IGalgameCollectionService
                     galgame.Description.Value = tmp.Description.Value;
                 if (tmp.Developer != Galgame.DefaultString)
                     galgame.Developer.Value = tmp.Developer.Value;
+                if (tmp.Engine != Galgame.DefaultString && !string.IsNullOrEmpty(tmp.Engine.Value))
+                    galgame.Engine.Value = tmp.Engine.Value;
                 if (tmp.ExpectedPlayTime != Galgame.DefaultString)
                     galgame.ExpectedPlayTime.Value = tmp.ExpectedPlayTime.Value;
                 switch (await LocalSettingsService.ReadSettingAsync<DisplayName>(KeyValues.DefaultGameName))

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -677,7 +677,7 @@ Since multiple data sources are involved, you need to configure relevant setting
     <value>Automatic categorization</value>
   </data>
   <data name="SettingsPage_Download_AutoCategory.Description" xml:space="preserve">
-    <value>After enabling, games will be automatically categorized by developer and play status</value>
+    <value>After enabling, games will be automatically categorized by developer, game engine, and play status</value>
   </data>
   <data name="SettingsPage_Download_CategoryNow.Title" xml:space="preserve">
     <value>Categorize all games</value>
@@ -729,6 +729,9 @@ Since multiple data sources are involved, you need to configure relevant setting
   </data>
   <data name="CategoryPage_CategoryNow.Label" xml:space="preserve">
     <value>Categorize all games</value>
+  </data>
+  <data name="CategoryPage_CategoryNow.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Categorize all games by play status, developer, and game engine</value>
   </data>
   <data name="SettingsPage_Start_AuthenticationType.Title" xml:space="preserve">
     <value>Authentication</value>
@@ -2936,7 +2939,7 @@ If play time can record correctly, just cancel this popup.
     <value>Categorize all games</value>
   </data>
   <data name="CategoryPage_CategoryNow_ConfirmMsg" xml:space="preserve">
-    <value>Categorize by game developer and actual play status within PotatoVN.\nThis will partially overwrite currently categorized developers and play statuses.</value>
+    <value>Categorize games by developer, game engine, and actual play status in PotatoVN.\nThis will partially overwrite currently categorized developers and play statuses.</value>
   </data>
   <data name="CategoryPage_CategoryGroup_Rename.Text" xml:space="preserve">
     <value>Rename category group</value>
@@ -3697,5 +3700,14 @@ If play time can record correctly, just cancel this popup.
   </data>
   <data name="HomePage_EngineFilter.Text" xml:space="preserve">
     <value>Engine</value>
+  </data>
+  <data name="HomePage_NoEngineCategory" xml:space="preserve">
+    <value>No engine category contains this game</value>
+  </data>
+  <data name="MixedPhraserOrderDialog_It_Engine" xml:space="preserve">
+    <value>Game Engine</value>
+  </data>
+  <data name="MixedPhraserEnabledDialog_EngineCheckBox.Content" xml:space="preserve">
+    <value>Fetch Game Engine</value>
   </data>
 </root>

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -3686,4 +3686,16 @@ If play time can record correctly, just cancel this popup.
   <data name="SettingsPage_Rss_VNDB_RemoveSpoilerTags.Description" xml:space="preserve">
     <value>Filter out VNDB tags marked as spoilers.</value>
   </data>
+  <data name="CategoryService_Engine" xml:space="preserve">
+    <value>Engine</value>
+  </data>
+  <data name="GalgamePage_Engine.Text" xml:space="preserve">
+    <value>Engine</value>
+  </data>
+  <data name="GalgameSettingPage_GalgameEngine.Title" xml:space="preserve">
+    <value>Engine</value>
+  </data>
+  <data name="HomePage_EngineFilter.Text" xml:space="preserve">
+    <value>Engine</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -677,7 +677,7 @@
     <value>自動カテゴリ</value>
   </data>
   <data name="SettingsPage_Download_AutoCategory.Description" xml:space="preserve">
-    <value>有効にすると、開発会社とプレイ状況に基づいてゲームを自動的に分類します。</value>
+    <value>有効にすると、開発会社、ゲームエンジン、およびプレイ状況に基づいてゲームを自動的に分類します。</value>
   </data>
   <data name="SettingsPage_Download_CategoryNow.Title" xml:space="preserve">
     <value>すべてのゲームをカテゴリ分け</value>
@@ -729,6 +729,9 @@
   </data>
   <data name="CategoryPage_CategoryNow.Label" xml:space="preserve">
     <value>すべてのゲームを分類</value>
+  </data>
+  <data name="CategoryPage_CategoryNow.ToolTipService.ToolTip" xml:space="preserve">
+    <value>プレイ状態、制作会社、ゲームエンジンですべてのゲームを分類</value>
   </data>
   <data name="SettingsPage_Start_AuthenticationType.Title" xml:space="preserve">
     <value>認証</value>
@@ -2942,7 +2945,7 @@
     <value>すべてのゲームを分類</value>
   </data>
   <data name="CategoryPage_CategoryNow_ConfirmMsg" xml:space="preserve">
-    <value>ゲームの制作会社とPotatoVN内での実際のプレイ状況に基づいて分類します。
+    <value>制作会社、ゲームエンジン、およびPotatoVN内の実際のプレイ状況に従ってゲームを分類します。
 これにより、現在分類されている制作会社とプレイ状況が部分的に上書きされます。</value>
   </data>
   <data name="CategoryPage_CategoryGroup_Rename.Text" xml:space="preserve">
@@ -3617,5 +3620,14 @@
   </data>
   <data name="HomePage_EngineFilter.Text" xml:space="preserve">
     <value>エンジン</value>
+  </data>
+  <data name="HomePage_NoEngineCategory" xml:space="preserve">
+    <value>このゲームを含むエンジンカテゴリはありません</value>
+  </data>
+  <data name="MixedPhraserOrderDialog_It_Engine" xml:space="preserve">
+    <value>ゲームエンジン</value>
+  </data>
+  <data name="MixedPhraserEnabledDialog_EngineCheckBox.Content" xml:space="preserve">
+    <value>ゲームエンジンを取得</value>
   </data>
 </root>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -3606,4 +3606,16 @@
   <data name="SettingsPage_Rss_VNDB_RemoveSpoilerTags.Description" xml:space="preserve">
     <value>ネタバレとして扱われる VNDB タグを除外します。</value>
   </data>
+  <data name="CategoryService_Engine" xml:space="preserve">
+    <value>エンジン</value>
+  </data>
+  <data name="GalgamePage_Engine.Text" xml:space="preserve">
+    <value>エンジン</value>
+  </data>
+  <data name="GalgameSettingPage_GalgameEngine.Title" xml:space="preserve">
+    <value>エンジン</value>
+  </data>
+  <data name="HomePage_EngineFilter.Text" xml:space="preserve">
+    <value>エンジン</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -4588,6 +4588,9 @@
   <data name="HomePage_EngineFilter.Text" xml:space="preserve">
     <value>游戏引擎</value>
   </data>
+  <data name="HomePage_NoEngineCategory" xml:space="preserve">
+    <value>无任何引擎分类包含本游戏</value>
+  </data>
   <data name="MixedPhraserOrderDialog_It_Engine" xml:space="preserve">
     <value>游戏引擎</value>
   </data>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -4576,4 +4576,16 @@
   <data name="SettingsPage_Rss_VNDB_RemoveSpoilerTags.Description" xml:space="preserve">
     <value>过滤掉被 VNDB 标记为剧透的标签。</value>
   </data>
+  <data name="CategoryService_Engine" xml:space="preserve">
+    <value>游戏引擎</value>
+  </data>
+  <data name="GalgamePage_Engine.Text" xml:space="preserve">
+    <value>游戏引擎</value>
+  </data>
+  <data name="GalgameSettingPage_GalgameEngine.Title" xml:space="preserve">
+    <value>游戏引擎</value>
+  </data>
+  <data name="HomePage_EngineFilter.Text" xml:space="preserve">
+    <value>游戏引擎</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -729,7 +729,7 @@
     <value>自动分类</value>
   </data>
   <data name="SettingsPage_Download_AutoCategory.Description" xml:space="preserve">
-    <value>启用后自动按制作公司和游玩状态对游戏进行分类</value>
+    <value>启用后自动按制作公司、游戏引擎和游玩状态对游戏进行分类</value>
   </data>
   <data name="SettingsPage_Download_CategoryNow.Title" xml:space="preserve">
     <value>分类所有游戏</value>
@@ -786,7 +786,7 @@
     <value>分类所有游戏</value>
   </data>
   <data name="CategoryPage_CategoryNow.ToolTipService.ToolTip" xml:space="preserve">
-    <value>根据游玩状态和制作公司对所有游戏进行分类</value>
+    <value>根据游玩状态、制作公司和游戏引擎对所有游戏进行分类</value>
   </data>
   <data name="SettingsPage_Start_AuthenticationType.Title" xml:space="preserve">
     <value>身份验证</value>
@@ -3131,7 +3131,7 @@
     <value>分类所有游戏</value>
   </data>
   <data name="CategoryPage_CategoryNow_ConfirmMsg" xml:space="preserve">
-    <value>按照游戏的制作公司和PotatoVN内的实际游玩情况进行分类
+    <value>按照游戏的制作公司、游戏引擎和PotatoVN内实际游玩情况进行分类
 这将部分覆盖目前已分类的制作公司和游玩状态</value>
   </data>
   <data name="CategoryPage_CategoryGroup_Rename.Text" xml:space="preserve">
@@ -4587,5 +4587,11 @@
   </data>
   <data name="HomePage_EngineFilter.Text" xml:space="preserve">
     <value>游戏引擎</value>
+  </data>
+  <data name="MixedPhraserOrderDialog_It_Engine" xml:space="preserve">
+    <value>游戏引擎</value>
+  </data>
+  <data name="MixedPhraserEnabledDialog_EngineCheckBox.Content" xml:space="preserve">
+    <value>获取游戏引擎</value>
   </data>
 </root>

--- a/GalgameManager/ViewModels/HomeViewModel.cs
+++ b/GalgameManager/ViewModels/HomeViewModel.cs
@@ -294,15 +294,17 @@ public partial class HomeViewModel : ObservableObject, INavigationAware
     [ObservableProperty] private string _uiFilter = string.Empty; //过滤器在AppBar上的文本
     [ObservableProperty] private bool _keepFilters; //是否保留过滤器
     [ObservableProperty] private string _filterInputText = string.Empty; //过滤器输入框的文本
-    public AdvancedCollectionView TagFilters = [], DeveloperFilters = [], SourceFilters = [], PlayStatusFilters = [];
+    public AdvancedCollectionView TagFilters = [], DeveloperFilters = [], EngineFilters = [], SourceFilters = [], PlayStatusFilters = [];
     private readonly ObservableCollection<HomeViewModelFilter> _tagFiltersC = [], _developerFiltersC = [],
-        _sourceFiltersC = [], _playStatusFiltersC = [];
+        _engineFiltersC = [], _sourceFiltersC = [], _playStatusFiltersC = [];
     [ObservableProperty] private string _tagFilterSearchKey = string.Empty;
     [ObservableProperty] private string _developerFilterSearchKey = string.Empty;
+    [ObservableProperty] private string _engineFilterSearchKey = string.Empty;
     [ObservableProperty] private HomeViewModelFilter? _selectedPlayStatus;
 
     private bool _tagFilterCalc;
     private bool _developerFilterCalc;
+    private bool _engineFilterCalc;
     private bool _sourceFilterCalc;
     private bool _playStatusInit;
 
@@ -310,6 +312,7 @@ public partial class HomeViewModel : ObservableObject, INavigationAware
     {
         TagFilters.Source = _tagFiltersC;
         DeveloperFilters.Source = _developerFiltersC;
+        EngineFilters.Source = _engineFiltersC;
         SourceFilters.Source = _sourceFiltersC;
         PlayStatusFilters.Source = _playStatusFiltersC;
         _tagFilterCalc = false;
@@ -353,6 +356,20 @@ public partial class HomeViewModel : ObservableObject, INavigationAware
                 DeveloperFilters.Filter = f => f is HomeViewModelFilter filter &&
                                               filter.Title.ContainX(DeveloperFilterSearchKey);
                 _developerFilterCalc = true;
+            }
+            if (!_engineFilterCalc)
+            {
+                Dictionary<Category, int> allEngines = []; //value为包含该引擎(分类)的游戏数量
+                foreach (Category engine in _categoryService.EngineGroup.Categories)
+                {
+                    allEngines.TryAdd(engine, 0);
+                    allEngines[engine] = engine.GalgamesX.Count;
+                }
+                await SetFilterList(EngineFilters, allEngines, category => new CategoryFilter(category),
+                    (filter, category) => filter is CategoryFilter c && c.Category.Id == category.Id);
+                EngineFilters.Filter = f => f is HomeViewModelFilter filter &&
+                                           filter.Title.ContainX(EngineFilterSearchKey);
+                _engineFilterCalc = true;
             }
             if (!_sourceFilterCalc)
             {
@@ -432,6 +449,19 @@ public partial class HomeViewModel : ObservableObject, INavigationAware
     }
 
     [RelayCommand]
+    private void SearchEngineFilter()
+    {
+        try
+        {
+            EngineFilters.RefreshFilter();
+        }
+        catch (Exception e)
+        {
+            _infoService.DeveloperEvent(e: e);
+        }
+    }
+
+    [RelayCommand]
     private void ClearPlayStatus() => SelectedPlayStatus = null;
 
     partial void OnKeepFiltersChanged(bool value) => _localSettingsService.SaveSettingAsync(KeyValues.KeepFilters, value);
@@ -451,8 +481,10 @@ public partial class HomeViewModel : ObservableObject, INavigationAware
 
     private void HandleCategoryGroupChanged(object recipient, CategoryGroupChangedArg message)
     {
-        if (message.Group.Type != CategoryGroupType.Developer) return;
-        _developerFilterCalc = false;
+        if (message.Group.Type == CategoryGroupType.Developer)
+            _developerFilterCalc = false;
+        else if (message.Group.Type == CategoryGroupType.Engine)
+            _engineFilterCalc = false;
     }
 
     private void HandleSourceChanged() => _sourceFilterCalc = false;

--- a/GalgameManager/Views/Dialog/MixedPhraserEnabledDialog.xaml
+++ b/GalgameManager/Views/Dialog/MixedPhraserEnabledDialog.xaml
@@ -22,6 +22,7 @@
                 <CheckBox x:Name="NameCheckBox" x:Uid="MixedPhraserEnabledDialog_NameCheckBox" />
                 <CheckBox x:Name="DescriptionCheckBox" x:Uid="MixedPhraserEnabledDialog_DescriptionCheckBox" />
                 <CheckBox x:Name="DeveloperCheckBox" x:Uid="MixedPhraserEnabledDialog_DeveloperCheckBox" />
+                <CheckBox x:Name="EngineCheckBox" x:Uid="MixedPhraserEnabledDialog_EngineCheckBox" />
                 <CheckBox x:Name="TagsCheckBox" x:Uid="MixedPhraserEnabledDialog_TagsCheckBox" />
                 <CheckBox x:Name="RatingCheckBox" x:Uid="MixedPhraserEnabledDialog_RatingCheckBox" />
                 <CheckBox x:Name="ExpectedPlayTimeCheckBox" x:Uid="MixedPhraserEnabledDialog_ExpectedPlayTimeCheckBox" />

--- a/GalgameManager/Views/Dialog/MixedPhraserEnabledDialog.xaml.cs
+++ b/GalgameManager/Views/Dialog/MixedPhraserEnabledDialog.xaml.cs
@@ -20,6 +20,7 @@ public sealed partial class MixedPhraserEnabledDialog
             NameEnabled = enabled.NameEnabled,
             DescriptionEnabled = enabled.DescriptionEnabled,
             DeveloperEnabled = enabled.DeveloperEnabled,
+            EngineEnabled = enabled.EngineEnabled,
             TagsEnabled = enabled.TagsEnabled,
             RatingEnabled = enabled.RatingEnabled,
             ExpectedPlayTimeEnabled = enabled.ExpectedPlayTimeEnabled,
@@ -39,6 +40,7 @@ public sealed partial class MixedPhraserEnabledDialog
         NameCheckBox.IsChecked = enabled.NameEnabled;
         DescriptionCheckBox.IsChecked = enabled.DescriptionEnabled;
         DeveloperCheckBox.IsChecked = enabled.DeveloperEnabled;
+        EngineCheckBox.IsChecked = enabled.EngineEnabled;
         TagsCheckBox.IsChecked = enabled.TagsEnabled;
         RatingCheckBox.IsChecked = enabled.RatingEnabled;
         ExpectedPlayTimeCheckBox.IsChecked = enabled.ExpectedPlayTimeEnabled;
@@ -62,6 +64,7 @@ public sealed partial class MixedPhraserEnabledDialog
         Result.NameEnabled = NameCheckBox.IsChecked ?? false;
         Result.DescriptionEnabled = DescriptionCheckBox.IsChecked ?? false;
         Result.DeveloperEnabled = DeveloperCheckBox.IsChecked ?? false;
+        Result.EngineEnabled = EngineCheckBox.IsChecked ?? false;
         Result.TagsEnabled = TagsCheckBox.IsChecked ?? false;
         Result.RatingEnabled = RatingCheckBox.IsChecked ?? false;
         Result.ExpectedPlayTimeEnabled = ExpectedPlayTimeCheckBox.IsChecked ?? false;

--- a/GalgameManager/Views/Dialog/MixedPhraserOrderDialog.xaml.cs
+++ b/GalgameManager/Views/Dialog/MixedPhraserOrderDialog.xaml.cs
@@ -39,6 +39,7 @@ public sealed partial class MixedPhraserOrderDialog
             new MixedPhraserOrderDialogItem("MixedPhraserOrderDialog_It_Character".GetLocalized(), _order.CharactersOrder),
             new MixedPhraserOrderDialogItem("MixedPhraserOrderDialog_It_CnName".GetLocalized(), _order.CnNameOrder),
             new MixedPhraserOrderDialogItem("MixedPhraserOrderDialog_It_Dev".GetLocalized(), _order.DeveloperOrder),
+            new MixedPhraserOrderDialogItem("MixedPhraserOrderDialog_It_Engine".GetLocalized(), _order.EngineOrder),
             new MixedPhraserOrderDialogItem("MixedPhraserOrderDialog_It_Tag".GetLocalized(), _order.TagsOrder),
             new MixedPhraserOrderDialogItem("MixedPhraserOrderDialog_It_Staff".GetLocalized(), _order.StaffOrder),
         };

--- a/GalgameManager/Views/GalgamePagePanel/GameHeaderPanel.xaml
+++ b/GalgameManager/Views/GalgamePagePanel/GameHeaderPanel.xaml
@@ -17,6 +17,7 @@
         <converter:DateTimeToStringConverter x:Key="DateTimeToStringConverter" />
         <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <converter:ImagePathConverter x:Key="ImagePathConverter"/>
+        <converters:StringVisibilityConverter x:Key="StringVisibilityConverter" />
     </UserControl.Resources>
 
     <Grid x:Name="ContentRoot">
@@ -79,6 +80,14 @@
                                     <cmtkControls:WrapLayout Orientation="Horizontal" HorizontalSpacing="5" />
                                 </ItemsRepeater.Layout>
                             </ItemsRepeater>
+                        </StackPanel>
+                        <!-- 游戏引擎 -->
+                        <StackPanel Style="{StaticResource KeyValue}"
+                                    Visibility="{x:Bind Game.Engine.Value, Mode=OneWay, Converter={StaticResource StringVisibilityConverter}}">
+                            <TextBlock x:Uid="GalgamePage_Engine"
+                                       Style="{ThemeResource BodyStrongTextBlockStyle}" />
+                            <HyperlinkButton Content="{x:Bind Game.Engine.Value, Mode=OneWay, FallbackValue={}}"
+                                             Click="ClickEngine" Padding="0" Margin="0"/>
                         </StackPanel>
                         <!-- 发布日期 -->
                         <StackPanel Style="{StaticResource KeyValue}" Margin="0 -1 0 0">

--- a/GalgameManager/Views/GalgamePagePanel/GameHeaderPanel.xaml
+++ b/GalgameManager/Views/GalgamePagePanel/GameHeaderPanel.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <local:GamePanelBase
     x:Class="GalgameManager.Views.GalgamePagePanel.GameHeaderPanel"
@@ -17,7 +17,7 @@
         <converter:DateTimeToStringConverter x:Key="DateTimeToStringConverter" />
         <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <converter:ImagePathConverter x:Key="ImagePathConverter"/>
-        <converters:StringVisibilityConverter x:Key="StringVisibilityConverter" />
+        <converter:DefaultStringToVisibilityConverter x:Key="DefaultStringToVisibilityConverter" />
     </UserControl.Resources>
 
     <Grid x:Name="ContentRoot">
@@ -83,7 +83,7 @@
                         </StackPanel>
                         <!-- 游戏引擎 -->
                         <StackPanel Style="{StaticResource KeyValue}"
-                                    Visibility="{x:Bind Game.Engine.Value, Mode=OneWay, Converter={StaticResource StringVisibilityConverter}}">
+                                    Visibility="{x:Bind Game.Engine.Value, Mode=OneWay, Converter={StaticResource DefaultStringToVisibilityConverter}}">
                             <TextBlock x:Uid="GalgamePage_Engine"
                                        Style="{ThemeResource BodyStrongTextBlockStyle}" />
                             <HyperlinkButton Content="{x:Bind Game.Engine.Value, Mode=OneWay, FallbackValue={}}"

--- a/GalgameManager/Views/GalgamePagePanel/GameHeaderPanel.xaml.cs
+++ b/GalgameManager/Views/GalgamePagePanel/GameHeaderPanel.xaml.cs
@@ -220,6 +220,20 @@ public partial class GameHeaderPanel
         _navigationService.NavigateTo(typeof(HomeViewModel).FullName!);
     }
 
+    private void ClickEngine(object sender, RoutedEventArgs e)
+    {
+        if (Game is null) return;
+        Category? category = _categoryService.GetEngineCategory(Game);
+        if (category is null)
+        {
+            _infoService.Info(InfoBarSeverity.Error, msg: "HomePage_NoEngineCategory".GetLocalized());
+            return;
+        }
+        _filterService.ClearFilters();
+        _filterService.AddFilter(new CategoryFilter(category));
+        _navigationService.NavigateTo(typeof(HomeViewModel).FullName!);
+    }
+
     private void ClickStaff(object sender, RoutedEventArgs e)
     {
         if (sender is not HyperlinkButton button || button.DataContext is not Staff staff) return;

--- a/GalgameManager/Views/GalgameSettingPage.xaml
+++ b/GalgameManager/Views/GalgameSettingPage.xaml
@@ -222,6 +222,13 @@
                                     Value="{x:Bind ViewModel.Gal.Developer.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                     IsLock="{x:Bind ViewModel.Gal.Developer.IsLock, Mode=TwoWay}" />
                             </control:Panel>
+                            <!-- 游戏引擎 -->
+                            <control:Panel>
+                                <control:LockableTextBox
+                                    x:Uid="GalgameSettingPage_GalgameEngine"
+                                    Value="{x:Bind ViewModel.Gal.Engine.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                    IsLock="{x:Bind ViewModel.Gal.Engine.IsLock, Mode=TwoWay}" />
+                            </control:Panel>
                             <!-- 预计游玩时长 -->
                             <control:Panel>
                                 <control:LockableTextBox

--- a/GalgameManager/Views/HomePage.xaml
+++ b/GalgameManager/Views/HomePage.xaml
@@ -138,7 +138,7 @@
                     </AppBarButton.Icon>
                     <AppBarButton.Flyout>
                         <Flyout Placement="Bottom">
-                            <Grid ColumnDefinitions="*,*,*" RowDefinitions="*,Auto,Auto" Height="260" Width="400" ColumnSpacing="10">
+                            <Grid ColumnDefinitions="*,*,*,*" RowDefinitions="*,Auto,Auto" Height="260" Width="400" ColumnSpacing="10">
                                 <Grid Grid.Column="0" RowDefinitions="Auto,Auto,Auto,*">
                                     <TextBlock Grid.Row="0" x:Uid="HomePage_PlayStatusFilter"
                                                FontWeight="SemiBold" Margin="{StaticResource XXSmallBottomMargin}"/>
@@ -169,6 +169,23 @@
                                     </ScrollViewer>
                                 </Grid>
                                 <Grid Grid.Column="1" RowDefinitions="Auto,Auto,*">
+                                    <TextBlock Grid.Row="0" x:Uid="HomePage_EngineFilter"
+                                                 FontWeight="SemiBold" Margin="{StaticResource XXSmallBottomMargin}"/>
+                                    <control:SearchAutoSuggestBox Grid.Row="1" MinWidth="0"
+                                                                    SearchKey="{x:Bind ViewModel.EngineFilterSearchKey, Mode=TwoWay}"
+                                                                    SearchCommand="{x:Bind ViewModel.SearchEngineFilterCommand}"
+                                                                    Margin="0 0 10 0"/>
+                                    <ScrollViewer Grid.Row="2">
+                                        <ItemsRepeater ItemsSource="{x:Bind ViewModel.EngineFilters}">
+                                            <DataTemplate x:DataType="viewModels:HomeViewModelFilter">
+                                                <CheckBox IsThreeState="True"
+                                                            IsChecked="{x:Bind IsChecked, Mode=TwoWay}"
+                                                            Content="{x:Bind Title}"/>
+                                            </DataTemplate>
+                                        </ItemsRepeater>
+                                    </ScrollViewer>
+                                </Grid>
+                                <Grid Grid.Column="2" RowDefinitions="Auto,Auto,*">
                                     <TextBlock Grid.Row="0" x:Uid="HomePage_DeveloperFilter"
                                                FontWeight="SemiBold" Margin="{StaticResource XXSmallBottomMargin}"/>
                                     <control:SearchAutoSuggestBox Grid.Row="1" MinWidth="0"
@@ -185,7 +202,7 @@
                                         </ItemsRepeater>
                                     </ScrollViewer>
                                 </Grid>
-                                <Grid Grid.Column="2" RowDefinitions="Auto,Auto,*">
+                                <Grid Grid.Column="3" RowDefinitions="Auto,Auto,*">
                                     <TextBlock Grid.Row="0" x:Uid="HomePage_TagFilter"
                                                FontWeight="SemiBold" Margin="{StaticResource XXSmallBottomMargin}"/>
                                     <control:SearchAutoSuggestBox SearchKey="{x:Bind ViewModel.TagFilterSearchKey, Mode=TwoWay}"


### PR DESCRIPTION
  - 新增 Engine 字段到 Galgame 模型
  - 从 VNDB release API 同步获取最新版本游戏引擎信息
  - 在游戏详情页和设置页添加引擎显示与编辑功能
  - 添加引擎分类组，支持按引擎过滤游戏列表
  - 在 MixedPhraser 中合并多数据源的引擎数据
  - 更新过滤菜单，添加游戏引擎过滤选项
  - 添加本地化字符串支持（中/日/英）
  - 使用 LockableProperty 实现引擎字段的锁定功能
  - MixedPhraser 版本升级到 13 以支持新字段